### PR TITLE
ENH: EGU Axes

### DIFF
--- a/archive_viewer/mixins/traces_table.py
+++ b/archive_viewer/mixins/traces_table.py
@@ -275,7 +275,7 @@ class FormulaDialog(QDialog):
         """ Retrieve the formula and PV name and perform desired actions
          We take in the formula (prepend the formula tag) and attempt to create a curve. Iff it passes, we close the window"""
         formula = "f://" + self.field.text()
-        passed = self.curveModel.replaceToFormula(index = self.curveModel.index(self.parent().selected_index.row(), 0), formula = formula)
+        passed = self.curveModel.set_data(column_name="Channel",  curve=self.curveModel._plot._curves[self.parent().selected_index.row()], value=formula)
         if passed:
             self.field.setText("")
             self.accept()

--- a/archive_viewer/table_models/axis_model.py
+++ b/archive_viewer/table_models/axis_model.py
@@ -169,6 +169,7 @@ class ArchiverAxisModel(BasePlotAxesModel):
         super().removeAtIndex(index)
 
     def removeAxis(self, axisName: str):
+        """Wrapper to remove axis by name. Searches through axes, finds the one with a matching name, removes at index"""
         for i, axis in enumerate(self.plot._axes):
             if axis.name == axisName:
                 self.removeAtIndex(self.index(i, 0))

--- a/archive_viewer/table_models/axis_model.py
+++ b/archive_viewer/table_models/axis_model.py
@@ -168,6 +168,11 @@ class ArchiverAxisModel(BasePlotAxesModel):
             self.remove_curve.emit(curve)
         super().removeAtIndex(index)
 
+    def removeAxis(self, axisName: str):
+        for i, axis in enumerate(self.plot._axes):
+            if axis.name == axisName:
+                self.removeAtIndex(self.index(i, 0))
+
     def setHidden(self, axis: BasePlotAxisItem, hidden: bool) -> None:
         """Hides the axis at the given table index.
 

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -102,7 +102,6 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         if column_name == "Channel":
             curve.show()
             # If we are changing the channel, then we need to check the current type, and the type we're going to
-            index = self.index(self._plot._curves.index(curve),0)
             value_is_formula = value.startswith("f://")
             curve_is_formula = isinstance(curve, FormulaCurveItem)
             if value_is_formula and not curve_is_formula:
@@ -164,6 +163,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         else:
             ret_code = super(ArchiverCurveModel, self).set_data(column_name, curve, value)
         self.plot.plotItem.autoVisible(curve.y_axis_name)
+        self.dataChanged.emit(index, index)
         logger.debug("Finished setting curve data")
         return ret_code
 
@@ -194,6 +194,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         if self.rowCount() != 1:
             logger.debug("Hide blank Y-axis")
             self._axis_model.plot.plotItem.axes[y_axis.name]["item"].hide()
+        self._plot._curves[-1].unitSignal.connect(partial(self.setAxis, curve=self._plot._curves[-1]))
         logger.debug("Finished adding new empty curve to plot")
 
     def set_model_curves(self, curves: List[Dict] = []) -> None:
@@ -252,6 +253,20 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         self._plot.redrawPlot()
         self.endResetModel()
         logger.debug("Finished setting curves model")
+
+    @Slot(str)
+    def setAxis(self, units: str, curve: BasePlotCurveItem):
+        """When we receive a unit of the curve, we will connect it to the correct axis"""
+        index = self.index(self._plot._curves.index(curve),0)
+
+        self.parent().update()
+        oldYAxis = curve.y_axis_name
+        if units not in self.plot.plotItem.axes:
+            self._axis_model.append(name=units)
+        self.setData(self.index(index.row(), self._column_names.index("Y-Axis Name")), units, Qt.EditRole)
+        if not self.plot.plotItem.axes[oldYAxis]["item"]._curves:
+            self._axis_model.removeAxis(oldYAxis)
+
 
     def replaceToArchivePlot(self, curve: BasePlotCurveItem, index: QModelIndex, address: str, color: Optional[QColor] = None):
         """Replace the existing curve with a new ArchivePlotCurveItem"""
@@ -359,7 +374,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         curve = self._plot._curves[rindex]
         self.beginRemoveRows(QModelIndex(), index.row(), index.row())
         if curve.y_axis_name in self._plot.plotItem.axes:
-            self.plot.plotItem.unlinkDataFromAxis(curve.y_axis_name)
+            self.plot.plotItem.unlinkDataFromAxis(curve)
         self.plot.removeItem(curve)
         self.plot._curves.remove(curve)
         self.endRemoveRows()

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -49,7 +49,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             If the channel already exists in the model
         """
         for curve in self._plot._curves:
-            if hasattr(curve, "channel"):
+            if isinstance(curve, ArchivePlotCurveItem):
                 if curve.address == key:
                     return True
             elif curve.formula == key:
@@ -137,6 +137,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             self.plot._legend.removeItem(curve.name())
             curve.setData(name=str(value))
             self.plot._legend.addItem(curve, curve.name())
+            self.plot.plotItem.axes[curve.y_axis_name]["item"].setLabel(curve.name())
         elif column_name == "Y-Axis Name":
             # If we change the Y-Axis, unlink from previous and link to new
             if value == curve.y_axis_name:
@@ -358,6 +359,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         self._plot._curves[index.row()] = FormulaCurve
         FormulaCurve.formula_invalid_signal.connect(partial(self.invalidFormula, header = rowName))
         # Need to check if Formula is referencing a dead row
+        self.plot.plotItem.unlinkDataFromAxis(curve)
         self.plot.removeItem(curve)
         # Disconnect everything and delete it, create a new Formula with the dictionary of curve
         [ch.disconnect() for ch in curve.channels() if ch]

--- a/archive_viewer/widgets/item_delegates.py
+++ b/archive_viewer/widgets/item_delegates.py
@@ -26,6 +26,9 @@ class EditorDelegate(QStyledItemDelegate):
         model = self.parent().model()
         model.modelAboutToBeReset.connect(self.reset_editors)
 
+    def updateEditorGeometry(self, editor, option, index):
+        editor.setGeometry(option.rect)
+
     def paint(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
         """Create a new persistent editor on the Table View at the given index.
 
@@ -473,8 +476,7 @@ class DeleteRowDelegate(EditorDelegate):
         """
         model.removeAtIndex(index)
 
-
-class ComboBoxDelegate(QStyledItemDelegate):
+class ComboBoxDelegate(EditorDelegate):
     """ComboBoxDelegate is a QStyledItemDelegate to display a persistent
     QComboBox widget on a QTableView.
 
@@ -486,34 +488,19 @@ class ComboBoxDelegate(QStyledItemDelegate):
     data_source : ArchiverAxisModel, list, dict
         The initial dataset to use when populating the QComboBox.
     """
-    sigTextChange = Signal(int, str)
-
     def __init__(self, parent: QTableView, data_source: Union[QAbstractItemModel, list, dict]) -> None:
         super().__init__(parent)
         if isinstance(data_source, list):
             data_source = {v: v for v in data_source}
         self.data_source = data_source
 
-        self.editor_list = []
-        model = self.parent().model()
-        model.modelAboutToBeReset.connect(self.reset_editors)
-
-    def initStyleOption(self, option: QStyleOptionViewItem, index: QModelIndex):
-        """Initialize a QComboBox for use in the Table View.
-
-        Parameters
-        ----------
-        option : QStyleOptionViewItem
-            The style option used to render the QComboBox
-        index : QModelIndex
-            The index to display the QComboBox on
-        """
+    def createEditor(self, parent: QWidget, option: QStyleOptionViewItem, index: QModelIndex) -> QWidget:
         if index.row() >= len(self.editor_list):
-            editor = QComboBox()
+            editor = QComboBox(parent)
+            value = index.data(Qt.DisplayRole)
 
             if isinstance(self.data_source, dict):
                 editor.addItems(self.data_source.keys())
-                value = index.data(Qt.DisplayRole)
                 if str(value) in self.data_source:
                     editor.setCurrentText(str(value))
                 else:
@@ -522,7 +509,6 @@ class ComboBoxDelegate(QStyledItemDelegate):
             elif isinstance(self.data_source, QAbstractItemModel):
                 editor.setModel(self.data_source)
                 editor.setModelColumn(0)
-                value = index.data(Qt.DisplayRole)
                 editor.setCurrentText(str(value))
 
             editor.setFocusPolicy(Qt.StrongFocus)
@@ -531,24 +517,8 @@ class ComboBoxDelegate(QStyledItemDelegate):
             editor.currentIndexChanged.connect(lambda: self.commitData.emit(editor))
 
             self.editor_list.append(editor)
-            self.parent().setIndexWidget(index, editor)
+            return editor
         return super().initStyleOption(option, index)
-
-    def destroyEditor(self, editor: QComboBox, index: QModelIndex) -> None:
-        """Destroy the editor for a defined index.
-
-        Parameters
-        ----------
-        editor : QComboBox
-            The editor to be destroyed
-        index : QModelIndex
-            The index of the editor to be destroyed
-        """
-        if index.row() < len(self.editor_list):
-            self.editor_list[index.row()].deleteLater()
-            del self.editor_list[index.row()]
-            return
-        return super().destroyEditor(editor, index)
 
     def setEditorData(self, editor: QComboBox, index: QModelIndex) -> None:
         """Set the editor's data to match the table model's data.
@@ -561,10 +531,13 @@ class ComboBoxDelegate(QStyledItemDelegate):
         index : QModelIndex
             The index of the editor to be changed.
         """
+
         value = index.data(Qt.DisplayRole)
-        ind = editor.findText(value)
-        if ind >= 0:
-            editor.setCurrentIndex(ind)
+        if isinstance(value, str):
+            value = editor.findText(value)
+
+        if isinstance(value, int):
+            editor.setCurrentIndex(value)
 
     def setModelData(self, editor: QComboBox, model: QAbstractTableModel, index: QModelIndex) -> None:
         """Set the table model's data to match the editor's data.
@@ -582,7 +555,6 @@ class ComboBoxDelegate(QStyledItemDelegate):
         if isinstance(self.data_source, dict):
             data = self.data_source[curr_text]
         elif isinstance(self.data_source, QAbstractItemModel):
-            self.sigTextChange.emit(index.row(), curr_text)
             data = curr_text
         model.setData(index, data, Qt.EditRole)
 
@@ -605,19 +577,6 @@ class ComboBoxDelegate(QStyledItemDelegate):
             return True
         return super().eventFilter(object, event)
 
-    @Slot()
-    def reset_editors(self) -> None:
-        """Slot called when the delegate's model will be reset. Closes all
-        persistent editors in the delegate.
-        """
-        for editor in self.editor_list:
-            editor_pos = editor.pos()
-            index = self.parent().indexAt(editor_pos)
-
-            editor.deleteLater()
-            self.parent().closePersistentEditor(index)
-        self.editor_list = []
-
     @Slot(QPoint)
     def combo_menu_requested(self, pos: QPoint) -> None:
         """Redirect menu requests to the Table View.
@@ -629,7 +588,6 @@ class ComboBoxDelegate(QStyledItemDelegate):
         """
         pos = self.sender().mapToParent(pos)
         self.parent().customContextMenuRequested.emit(pos)
-
 
 class InsertPVDelegate(EditorDelegate):
     """InsertPVDelegate is a QStyledItemDelegate to display a persistent


### PR DESCRIPTION
Instead of automatically adding new axes for every curve, wait for the asynchronous reception of EGUs from the timeplot plugin. Use these units to attach the curve to the correct axis where EGU = axis name. If no such axis exists, create a new axis for it. 

If we never receive an EGU signal, this is a PV with no EGU (for example PPS:IN20:1:MAGLOCK). If this happens, or it's a FormulaCurveItem, then change its axis name to match the *name* of the curve rather than the units, and it's a unique axis. Other curves can be added to that axis, but why would you want that? Perchance.

Because the signal for data comes in a few milliseconds before the signal for units, just how the timeplot plugin works, for a split second a new axis (the one that would be created because we didn't receive a units signal) would flash, then the curve would be put onto its correct axis. There is pretty much no way to fix this unless we sleep for a second or something to stall for the units signal. If that's worth it, we can do that.