### PR TITLE
ENH: Connection Status for Formula Curves

### DIFF
--- a/trace/mixins/traces_table.py
+++ b/trace/mixins/traces_table.py
@@ -42,12 +42,11 @@ class TracesTableMixin:
         self.menu = PVContextMenu(self)
         self.ui.traces_tbl.customContextMenuRequested.connect(self.custom_context_menu)
 
-        self.hdr = self.ui.traces_tbl.horizontalHeader()
-        self.hdr.setSectionResizeMode(QHeaderView.Stretch)
-        channel_col = self.curves_model.getColumnIndex("Channel")
-        self.hdr.setSectionResizeMode(channel_col, QHeaderView.ResizeToContents)
-        del_col = self.curves_model.getColumnIndex("")
-        self.hdr.setSectionResizeMode(del_col, QHeaderView.ResizeToContents)
+        hdr = self.ui.traces_tbl.horizontalHeader()
+        hdr.setSectionResizeMode(QHeaderView.Stretch)
+        for col_name in ("Channel", "Label", ""):
+            channel_col = self.curves_model.getColumnIndex(col_name)
+            hdr.setSectionResizeMode(channel_col, QHeaderView.ResizeToContents)
         self.setAcceptDrops(True)
         self.menu.archive_search.append_PVs_requested.connect(self.insertPVs)
         self.curves_model.multiplePVInsert.connect(self.insertPVs)
@@ -119,8 +118,6 @@ class TracesTableMixin:
             curve = self.curves_model.curve_at_index(index)
             self.curves_model.set_data(column_name="Channel", curve=curve, value=channel)
         self.ui.traces_tbl.update()
-        self.hdr.setSectionResizeMode(self.curves_model.getColumnIndex("Channel"), QHeaderView.ResizeToContents)
-        self.hdr.setSectionResizeMode(self.curves_model.getColumnIndex("Label"), QHeaderView.ResizeToContents)
 
     @Slot(QModelIndex)
     def update_index(self, index: QModelIndex) -> None:

--- a/trace/table_models/curve_model.py
+++ b/trace/table_models/curve_model.py
@@ -449,7 +449,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         [ch.disconnect() for ch in curve.channels() if ch]
         del curve
 
-        FormulaCurve.formula_invalid_signal.connect(partial(self.invalidFormula, header = rowName))
+        FormulaCurve.formula_invalid_signal.connect(partial(self.invalidFormula, header=rowName))
         FormulaCurve.live_channel_connection.connect(self.live_connection_slot)
         FormulaCurve.archive_channel_connection.connect(self.archive_connection_slot)
         FormulaCurve.connection_status_check()

--- a/trace/table_models/curve_model.py
+++ b/trace/table_models/curve_model.py
@@ -606,9 +606,14 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             self._invalid_live_channels.discard(curve)
         else:
             self._invalid_live_channels.add(curve)
+            inter = self._invalid_live_channels & self._invalid_arch_channels
+            if curve in inter:
+                curve.hide()
+                self._axis_model.plot.plotItem.autoVisible(curve.y_axis_name)
 
+        row = self._plot._curves.index(curve)
         col = self._column_names.index("Live Data")
-        ind = self.index(self._plot._curves.index(curve), col)
+        ind = self.index(row, col)
         self.invalid_index_signal.emit(ind)
 
     @Slot(bool)
@@ -627,7 +632,12 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             self._invalid_arch_channels.discard(curve)
         else:
             self._invalid_arch_channels.add(curve)
+            inter = self._invalid_live_channels & self._invalid_arch_channels
+            if curve in inter:
+                curve.hide()
+                self._axis_model.plot.plotItem.autoVisible(curve.y_axis_name)
 
+        row = self._plot._curves.index(curve)
         col = self._column_names.index("Archive Data")
-        ind = self.index(self._plot._curves.index(curve), col)
+        ind = self.index(row, col)
         self.invalid_index_signal.emit(ind)

--- a/trace/table_models/curve_model.py
+++ b/trace/table_models/curve_model.py
@@ -426,8 +426,6 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         color : Optional[QColor], optional
             The curve's color on the plot.
         """
-        # Find row headers using regex
-
         rowName = self._row_names[index.row()]
         pvdict = self.formulaToPVDict(rowName, formula)
         curve = self._plot._curves[index.row()]
@@ -450,6 +448,11 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         # Disconnect everything and delete it, create a new Formula with the dictionary of curve
         [ch.disconnect() for ch in curve.channels() if ch]
         del curve
+
+        FormulaCurve.formula_invalid_signal.connect(partial(self.invalidFormula, header = rowName))
+        FormulaCurve.live_channel_connection.connect(self.live_connection_slot)
+        FormulaCurve.archive_channel_connection.connect(self.archive_connection_slot)
+        FormulaCurve.connection_status_check()
         return True
 
     def invalidFormula(self, header):


### PR DESCRIPTION
Builds on #37 and relies on https://github.com/slaclab/pydm/pull/1111

Displays the connection status for both live and archive channels for formula curves. This is shown in 3 ways in the curve table, just like the referenced PR.

This PR also adds automatic hiding of curves if they are disconnected from both live and archive channels.
