### PR TITLE
ENH: Copy Paste Multiple PV Functionality

### DIFF
--- a/archive_viewer/mixins/traces_table.py
+++ b/archive_viewer/mixins/traces_table.py
@@ -1,6 +1,5 @@
-from typing import Dict, Any
+import re
 from qtpy.QtGui import QKeyEvent
-from qtpy import sip
 from qtpy.QtGui import QDragEnterEvent, QDragMoveEvent, QDropEvent
 from qtpy.QtCore import (Slot, QPoint, QModelIndex, QObject, Qt)
 from qtpy.QtWidgets import (QHeaderView, QMenu, QAction, QTableView, QDialog,
@@ -36,6 +35,7 @@ class TracesTableMixin:
         self.hdr.setSectionResizeMode(del_col, QHeaderView.ResizeToContents)
         self.setAcceptDrops(True)
         self.menu.archive_search.append_PVs_requested.connect(self.insertPVs)
+        self.curves_model.multiplePVInsert.connect(self.insertPVs)
 
     def curve_delegates_init(self) -> None:
         """Set column delegates for the Traces table to display widgets."""
@@ -96,9 +96,9 @@ class TracesTableMixin:
         Parameters
         ---------------
         data: str
-            The list of pvs in string format i.e. \"<pv1>, <pv2>, <pv3>\" etc."""
+            The list of pvs in string format with any white space or comma separation"""
         logger.info("Accepting PVs " + data)
-        channels = data.split(", ")
+        channels = re.split('[\s,]+', data)
         for channel in channels:
             index = -1
             curve = self.curves_model.curve_at_index(index)

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -2,7 +2,7 @@ import re
 from typing import (Any, List, Dict, Optional)
 from functools import partial
 from qtpy.QtGui import QColor
-from qtpy.QtCore import (QObject, QModelIndex, Qt, Slot)
+from qtpy.QtCore import (QObject, QModelIndex, Qt, Slot, Signal)
 from qtpy import sip
 from pydm.widgets.baseplot import BasePlot, BasePlotCurveItem
 from pydm.widgets.archiver_time_plot import ArchivePlotCurveItem, FormulaCurveItem
@@ -23,6 +23,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
     axis_model : ArchiverAxisModel
         The table model that stores the axes for the plot.
     """
+    multiplePVInsert = Signal(str)
 
     def __init__(self, parent: Optional[QObject], plot: BasePlot, axis_model: ArchiverAxisModel) -> None:
         super(ArchiverCurveModel, self).__init__(plot, parent)
@@ -101,6 +102,9 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         if sip.isdeleted(curve):
             return False
         if column_name == "Channel":
+            if re.search('[\s,]', value):
+                self.multiplePVInsert.emit(value)
+                return False
             curve.show()
             # If we are changing the channel, then we need to check the current type, and the type we're going to
             index = self.index(self._plot._curves.index(curve),0)

--- a/archive_viewer/widgets/archive_search.py
+++ b/archive_viewer/widgets/archive_search.py
@@ -187,6 +187,7 @@ class ArchiveSearchWidget(QWidget):
         search_text = self.search_box.text()
         search_text = search_text.replace("?", ".")
         search_text = search_text.replace("*", ".")
+        search_text = search_text.replace("%", ".")
         url_string = (
             f"http://{self.archive_url_textedit.text()}/"
             f"retrieval/bpl/searchForPVsRegex?regex=.*{search_text}.*"


### PR DESCRIPTION
Users can paste in a list of pvs separated by any white space (space, newline, tab, etc) or commas, and we will detect that there are multiple curves being inserted, split them up, and insert them separately.

Uses a simple regex to split, so our exact split delimiters can change but currently set to '[\s,]+' to detect white space and commas.

Potential issue: sometimes formulae have spaces i.e. f://{A} + {B} and this will split on those spaces.

This uses the same functionality as dragAndDropPV to insert multiple PVs at a time, and any curves with typos will be treated as if they were typed one at a time by the user, meaning a new row will form, we will attempt to connect and we wont be able to on a misspelled PV