### PR TITLE
FIX: Line Width and Symbol Size are in sync between table view and model

### DIFF
--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -75,6 +75,10 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
                 return "Direct"
         if column_name == "Hidden":
             return not curve.isVisible()
+        if column_name == "Line Width":
+            return str(int(curve.lineWidth)) + "px"
+        if column_name == "Symbol Size":
+            return str(int(curve.symbolSize))  + "px"
         return super(ArchiverCurveModel, self).get_data(column_name, curve)
 
     def set_data(self, column_name: str, curve: BasePlotCurveItem, value: Any) -> bool:


### PR DESCRIPTION
Slap a "px" onto necessary strings and it allows the item delegates combo box to read the value in directly rather than try to set indices incorrectly.