### PR TITLE
ENH: Switched every .pyav reference to .trc and added examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Config & Save files
 *.txt
 *.xml
-*.pyav
+*.trc
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -135,3 +135,6 @@ dmypy.json
 
 #
 .idea/
+
+# Debugger
+debug_archive_viewer.bash

--- a/archive_viewer/av_file_convert.py
+++ b/archive_viewer/av_file_convert.py
@@ -47,7 +47,7 @@ class ArchiveViewerFileConverter():
 
     def import_file(self, file_name: Union[str, Path] = None) -> Dict:
         """Import Archive Viewer save data from the provided file. The file
-        should be one of two types: '.pyav' or '.xml'. The data is returned as
+        should be one of two types: '.trc' or '.xml'. The data is returned as
         well as saved in the stored_data property.
 
         Parameters
@@ -83,7 +83,7 @@ class ArchiveViewerFileConverter():
 
     def export_file(self, file_name: Union[str, Path] = None, output_data: Union[Dict, PyDMTimePlot] = None) -> None:
         """Export the provided Archive Viewer save data to the provided file.
-        The file to export to should be of type '.pyav'. The provided data can
+        The file to export to should be of type '.trc'. The provided data can
         be either a dictionary or a PyDMTimePlot object. If no data is provided,
         then the converter's previously imported data is exported.
 
@@ -91,22 +91,22 @@ class ArchiveViewerFileConverter():
         ----------
         file_name : str or pathlib.Path
             The absolute file path of the file that save data should be written
-            to. Should be of file type '.pyav'.
+            to. Should be of file type '.trc'.
         output_data : dict or PyDMTimePlot, optional
             The data that should be exported, by default uses previously imported data
 
         Raises
         ------
         FileNotFoundError
-            If the provided file name does not match the expected output file type '.pyav'
+            If the provided file name does not match the expected output file type '.trc'
         ValueError
             If no output data is provided and the converter hasn't imported data previously
         """
         if file_name:
             self.output_file = Path(file_name)
         if not self.output_file.suffix:
-            self.output_file = self.output_file.with_suffix(".pyav")
-        elif not self.output_file.match("*.pyav"):
+            self.output_file = self.output_file.with_suffix(".trc")
+        elif not self.output_file.match("*.trc"):
             raise FileNotFoundError(f"Incorrect output file format: {self.output_file.suffix}")
 
         if not output_data:
@@ -380,10 +380,10 @@ def main(input_file: Path = None, output_file: Path = None, overwrite: bool = Fa
 
     # Check that the output file is usable
     if not output_file:
-        output_file = input_file.with_suffix(".pyav")
+        output_file = input_file.with_suffix(".trc")
     elif not output_file.suffix:
-        output_file = output_file.with_suffix(".pyav")
-    elif not output_file.match("*.pyav"):
+        output_file = output_file.with_suffix(".trc")
+    elif not output_file.match("*.trc"):
         raise FileNotFoundError(f"Incorrect output file format: {output_file}")
 
     # Check if file exists, and if it does if the overwrite flag is used

--- a/archive_viewer/examples/FormulaExample.trc
+++ b/archive_viewer/examples/FormulaExample.trc
@@ -1,0 +1,99 @@
+{
+    "archiver_url": "http://lcls-archapp.slac.stanford.edu",
+    "plot": {
+        "refreshInterval": 0.0,
+        "title": "",
+        "xGrid": false,
+        "yGrid": false,
+        "opacity": 128,
+        "backgroundColor": "#ffffff",
+        "legend": false,
+        "crosshair": false,
+        "mouseMode": 1
+    },
+    "time_axis": {
+        "name": "Main Time Axis",
+        "start": "2024-09-04 11:03:44",
+        "end": "2024-09-04 12:03:44",
+        "location": "bottom"
+    },
+    "y-axes": [
+        {
+            "name": "Axis 1",
+            "orientation": "left",
+            "minRange": -1.3843656974520628e-09,
+            "maxRange": 4.752694382245206e-08,
+            "autoRange": true,
+            "logMode": false
+        },
+        {
+            "name": "Axis 2",
+            "orientation": "left",
+            "minRange": 9.047133561624635e-10,
+            "maxRange": 1.3621653831337537e-08,
+            "autoRange": true,
+            "logMode": false
+        },
+        {
+            "name": "Axis 3",
+            "orientation": "left",
+            "minRange": 1.3015564414604301e-08,
+            "maxRange": 4.65547480853957e-08,
+            "autoRange": true,
+            "logMode": false
+        },
+        {
+            "name": "Axis 4",
+            "orientation": "left",
+            "minRange": -1.04,
+            "maxRange": 1.04,
+            "autoRange": true,
+            "logMode": false
+        }
+    ],
+    "curves": [
+        {
+            "useArchiveData": true,
+            "liveData": true,
+            "channel": "KLYS:LI22:31:KVAC",
+            "name": "KLYS:LI22:31:KVAC",
+            "color": "#008cf9",
+            "lineStyle": 1,
+            "lineWidth": 1,
+            "symbolSize": 10,
+            "yAxisName": "Axis 1",
+            "thresholdColor": "white"
+        },
+        {
+            "useArchiveData": true,
+            "liveData": true,
+            "channel": "KLYS:LI22:41:KVAC",
+            "name": "KLYS:LI22:41:KVAC",
+            "color": "#006e00",
+            "lineStyle": 1,
+            "lineWidth": 1,
+            "symbolSize": 10,
+            "yAxisName": "Axis 1",
+            "thresholdColor": "white"
+        }
+    ],
+    "formula": [
+        {
+            "useArchiveData": true,
+            "liveData": true,
+            "plot_style": "Line",
+            "formula": "f://{A}+{B}",
+            "curveDict": {
+                "A": "KLYS:LI22:31:KVAC",
+                "B": "KLYS:LI22:41:KVAC"
+            },
+            "name": "f://{A}+{B}",
+            "color": "#b80058",
+            "lineStyle": 1,
+            "lineWidth": 1,
+            "symbolSize": 10,
+            "yAxisName": "Axis 1",
+            "thresholdColor": "white"
+        }
+    ]
+}

--- a/archive_viewer/examples/PlotConfigExample.trc
+++ b/archive_viewer/examples/PlotConfigExample.trc
@@ -1,0 +1,53 @@
+{
+    "archiver_url": "http://lcls-archapp.slac.stanford.edu",
+    "plot": {
+        "refreshInterval": 0.0,
+        "title": "Very Cool Title",
+        "xGrid": true,
+        "yGrid": true,
+        "opacity": 255,
+        "backgroundColor": "#ffffff",
+        "legend": false,
+        "crosshair": false,
+        "mouseMode": 1
+    },
+    "time_axis": {
+        "name": "Main Time Axis",
+        "start": "2024-09-04 11:20:09",
+        "end": "2024-09-04 12:20:13",
+        "location": "bottom"
+    },
+    "y-axes": [
+        {
+            "name": "Axis 1",
+            "orientation": "left",
+            "minRange": 7.655507359823855e-09,
+            "maxRange": 3.336011764017615e-08,
+            "autoRange": true,
+            "logMode": false
+        },
+        {
+            "name": "Axis 2",
+            "orientation": "left",
+            "minRange": -1.04,
+            "maxRange": 1.04,
+            "autoRange": true,
+            "logMode": false
+        }
+    ],
+    "curves": [
+        {
+            "useArchiveData": true,
+            "liveData": true,
+            "channel": "KLYS:LI22:31:KVAC",
+            "name": "KLYS:LI22:31:KVAC",
+            "color": "#008cf9",
+            "lineStyle": 1,
+            "lineWidth": 1,
+            "symbolSize": 10,
+            "yAxisName": "Axis 1",
+            "thresholdColor": "white"
+        }
+    ],
+    "formula": []
+}

--- a/archive_viewer/mixins/file_io.py
+++ b/archive_viewer/mixins/file_io.py
@@ -22,7 +22,7 @@ class FileIOMixin:
         """Prompt the user for a file to export config data to"""
         file_name, _ = QFileDialog.getSaveFileName(self, "Save Archive Viewer",
                                                    str(self.io_path),
-                                                   "Python Archive Viewer (*.pyav)")
+                                                   "Python Archive Viewer (*.trc)")
         file_name = Path(file_name)
         if file_name.is_dir():
             logger.warning("No file name provided to export save file to")
@@ -42,7 +42,7 @@ class FileIOMixin:
         if not file_name:
             file_name, _ = QFileDialog.getOpenFileName(self, "Open Archive Viewer",
                                                        str(self.io_path),
-                                                       "Python Archive Viewer (*.pyav);;"
+                                                       "Python Archive Viewer (*.trc);;"
                                                        + "Java Archive Viewer (*.xml);;"
                                                        + "All Files (*)")
         file_name = Path(file_name)


### PR DESCRIPTION
Added debugger to gitignore for our QOL.

Deprecated .pyav extension in favor of .trc

Added Formula and Plot Config Import example .trc files to a new directory Archive-Viewer/archive_viewer/examples

Yes, they still import properly.

Can add more if wanted.