### PR TITLE
FIX: Minor fixes

### DIFF
--- a/trace/mixins/traces_table.py
+++ b/trace/mixins/traces_table.py
@@ -111,7 +111,7 @@ class TracesTableMixin:
         data: str
             The list of pvs in string format with any white space or comma separation"""
         logger.info("Accepting PVs " + data)
-        channels = re.split(r"[\s,]+", data)
+        channels = re.split(r"[\n\r,]+", data)
         for channel in channels:
             index = -1
             curve = self.curves_model.curve_at_index(index)

--- a/trace/mixins/traces_table.py
+++ b/trace/mixins/traces_table.py
@@ -305,12 +305,14 @@ class FormulaDialog(QDialog):
         """Set the curve in the curve model to use the entered formula. If the
         formula is invalid, then the dialog box is closed.
         """
+        row = self.parent().selected_index.row()
+        index = self.curveModel.index(row, 0)
+
         formula = "f://" + self.field.text()
-        passed = self.curveModel.set_data(
-            column_name="Channel",
-            curve=self.curveModel._plot._curves[self.parent().selected_index.row()],
-            value=formula,
-        )
+        formula = re.sub(r"\s+", "", formula)
+
+        passed = self.curveModel.setData(index, formula, Qt.EditRole)
+
         if passed:
             self.field.setText("")
             self.accept()

--- a/trace/table_models/axis_model.py
+++ b/trace/table_models/axis_model.py
@@ -189,17 +189,15 @@ class ArchiverAxisModel(BasePlotAxesModel):
         super().removeAtIndex(index)
 
     def removeAxis(self, axisName: str) -> None:
-        """Wrapper to remove axis by name. Searches through axes, finds the
-        one with a matching name, then calls removeAtIndex.
+        """Wrapper to remove axis by name.
 
         Parameters
         ----------
         axisName : str
             The name of the axis to be removed.
         """
-        for i, axis in enumerate(self.plot._axes):
-            if axis.name == axisName:
-                self.removeAtIndex(self.index(i, 0))
+        axis_index = [a.name for a in self.plot._axes].index(axisName)
+        self.removeAtIndex(self.index(axis_index, 0))
 
     def setHidden(self, axis: BasePlotAxisItem, hidden: bool) -> None:
         """Hides the axis at the given table index.

--- a/trace/table_models/curve_model.py
+++ b/trace/table_models/curve_model.py
@@ -63,10 +63,12 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         bool
             If the channel already exists in the model
         """
-        addresses = [c.address for c in self._plot._curves if hasattr(c, "address")]
-        formulas = [c.formula for c in self._plot._curves if hasattr(c, "formula")]
-
-        return key in addresses + formulas
+        for curve in self._plot._curves:
+            if hasattr(curve, "address") and curve.address == key:
+                return True
+            elif hasattr(curve, "formula") and curve.formula == key:
+                return True
+        return False
 
     def get_data(self, column_name: str, curve: ArchivePlotCurveItem) -> Any:
         """Get data from the model based on column name.

--- a/trace/table_models/curve_model.py
+++ b/trace/table_models/curve_model.py
@@ -117,7 +117,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         if sip.isdeleted(curve):
             return False
         if column_name == "Channel":
-            if re.search(r"[\s,]", value):
+            if re.search(r"[\n\r,]", value):
                 self.multiplePVInsert.emit(value)
                 return False
             # Check if this thing already in curves model


### PR DESCRIPTION
Some minor restructuring & reformatting in curve_model

- Removed `dataChanged` signal from `set_data` and fixed the reason it was being used
- Removed changing trace's label on when new Channel is set, this doesn't work as expected with EGU Axes
- Removed passing curve as argument in setAxis because we can get the curve with `self.sender()`
- Reformatted `__contains__`
- In `set_data`, won't allow users to use duplicate PVs or formulas (new)