### PR TITLE
ENH: Import and Convert StripTool Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Config & Save files
 *.txt
 *.xml
+*.stp
 *.trc
 
 # Byte-compiled / optimized / DLL files

--- a/docs/how_to/io.md
+++ b/docs/how_to/io.md
@@ -15,11 +15,20 @@ Trace's save files are in JSON format as to be human readable/writeable and they
 
 ### Java Save Files
 
-Save files for the Java-based Archive Viewer can also be imported into Trace. They are hidden in the file explorer by default. To show them, click the dropdown at the bottom of the file explorer dialog labeled `Files of type:` and select the option for `Java Archive Viewer (*.xml)`. Now you should be see only directories and `.xml` files.
+Save files for the Java-based Archive Viewer can also be imported into Trace. They can be found in the import tool's file selection tool along with Trace's save files. Users can show only Java Archive Viewer files by changing the file format filter at the bottom of the dialog window.
 
 Trace will not save new files in the Java-based Archive Viewer's format, only as `.trc` files.
 
 Files can be converted en masse from the Java-based file format to Trace's formate using the [CLI file converter tool](file_conversion.md).
+
+
+### StripTool Save Files
+
+Save files for the StripTool can be converted using the same tool or imported directly into Trace. They can be found in the import tool's file selection tool alongside Trace's save files and the Java Archive Viewer's save files. Users can show only StripTool files by changing the file format filter at the bottom of the dialog window.
+
+Trace will not save new files in the Java-based Archive Viewer's format, only as `.trc` files.
+
+Files can be converted en masse from the StripTool file format to Trace's formate using the [CLI file converter tool](file_conversion.md).
 
 
 ### Note About Colors

--- a/trace/examples/stp_conversion.stp
+++ b/trace/examples/stp_conversion.stp
@@ -1,0 +1,70 @@
+StripConfig                   1.2
+Strip.Time.Timespan           9600
+Strip.Time.NumSamples         7200
+Strip.Time.SampleInterval     1.000000
+Strip.Time.RefreshInterval    1.000000
+Strip.Color.Background        65535     65535     65535     
+Strip.Color.Foreground        0         0         0         
+Strip.Color.Grid              49087     49087     49087     
+Strip.Color.Color1            0         0         65535     
+Strip.Color.Color2            0         0         0         
+Strip.Color.Color3            60395     0         54484     
+Strip.Color.Color4            42405     0         0         
+Strip.Color.Color5            22873     65535     12850     
+Strip.Color.Color6            65535     0         0         
+Strip.Color.Color7            65535     0         0         
+Strip.Color.Color8            65535     55255     0         
+Strip.Color.Color9            48316     36751     36751     
+Strip.Color.Color10           39578     52685     12850     
+Strip.Option.GridXon          1
+Strip.Option.GridYon          1
+Strip.Option.AxisYcolorStat   1
+Strip.Option.GraphLineWidth   2
+Strip.Curve.0.Name            CLT:CP13:1005:LEVEL
+Strip.Curve.1.Name            CPT:CP11:1012:PRESS
+Strip.Curve.2.Name            CPT:CP12:1012:PRESS
+Strip.Curve.3.Name            CPT:CP12:1040:PRESS
+Strip.Curve.4.Name            CPT:CP14:1100:PRESS
+Strip.Curve.7.Name            GMGT:CP12:He:INVENTORY
+Strip.Curve.0.Units           %
+Strip.Curve.1.Units           bara
+Strip.Curve.2.Units           bara
+Strip.Curve.3.Units           bara
+Strip.Curve.4.Units           bara
+Strip.Curve.7.Units           kg
+Strip.Curve.0.Comment         Dewer Liquid Level
+Strip.Curve.1.Comment         CP1 MCS Clean Line
+Strip.Curve.2.Comment         Low Pressure In
+Strip.Curve.3.Comment         HP Out b4 final oil rmvl
+Strip.Curve.4.Comment         CC1 Inlet Pressure
+Strip.Curve.7.Comment         TOTAL_He_INVENTORY
+Strip.Curve.0.Precision       2
+Strip.Curve.1.Precision       2
+Strip.Curve.2.Precision       2
+Strip.Curve.3.Precision       2
+Strip.Curve.4.Precision       3
+Strip.Curve.7.Precision       2
+Strip.Curve.0.Min              30.00
+Strip.Curve.1.Min              3.00
+Strip.Curve.2.Min              1.00
+Strip.Curve.3.Min              12.00
+Strip.Curve.4.Min              0.021
+Strip.Curve.7.Min              2600.00
+Strip.Curve.0.Max              60.00
+Strip.Curve.1.Max              6.00
+Strip.Curve.2.Max              1.20
+Strip.Curve.3.Max              19.50
+Strip.Curve.4.Max              0.035
+Strip.Curve.7.Max              3200.00
+Strip.Curve.0.Scale           0
+Strip.Curve.1.Scale           0
+Strip.Curve.2.Scale           0
+Strip.Curve.3.Scale           0
+Strip.Curve.4.Scale           0
+Strip.Curve.7.Scale           0
+Strip.Curve.0.PlotStatus      1
+Strip.Curve.1.PlotStatus      1
+Strip.Curve.2.PlotStatus      1
+Strip.Curve.3.PlotStatus      1
+Strip.Curve.4.PlotStatus      1
+Strip.Curve.7.PlotStatus      1

--- a/trace/examples/xml_conversion.xml
+++ b/trace/examples/xml_conversion.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<AVConfiguration>
+    <connection_parameter>pbraw://lcls-archapp.slac.stanford.edu/retrieval</connection_parameter>
+    <time_axis name="Main Time Axis">
+        <start>-1d</start>
+        <end>07/11/2024 08:15:45</end>
+        <location>bottom</location>
+    </time_axis>
+    <range_axis name="Main Range Axis">
+        <min/>
+        <max/>
+        <type>log</type>
+        <location>left</location>
+    </range_axis>
+    <legend_configuration show_ave_name="true" show_directory_name="false" show_range="true" show_units="true"/>
+    <plot_title/>
+    <pv directory_name="Default" name="SBST:LI22:1:SDLY">
+        <time_axis_name>Main Time Axis</time_axis_name>
+        <range_axis_name>Main Range Axis</range_axis_name>
+        <color>-65536</color>
+        <draw_type>steps</draw_type>
+        <draw_width>1</draw_width>
+        <visibility>true</visibility>
+    </pv>
+    <pv directory_name="Default" name="KLYS:LI22:11:BCUR">
+        <time_axis_name>Main Time Axis</time_axis_name>
+        <range_axis_name>Main Range Axis</range_axis_name>
+        <color>-16776961</color>
+        <draw_type>steps</draw_type>
+        <draw_width>1</draw_width>
+        <visibility>true</visibility>
+    </pv>
+    <pv directory_name="Default" name="KLYS:LI22:31:KVAC">
+        <time_axis_name>Main Time Axis</time_axis_name>
+        <range_axis_name>Main Range Axis</range_axis_name>
+        <color>-16711936</color>
+        <draw_type>steps</draw_type>
+        <draw_width>1</draw_width>
+        <visibility>true</visibility>
+    </pv>
+    <pv directory_name="Default" name="KLYS:LI22:51:GOLD">
+        <time_axis_name>Main Time Axis</time_axis_name>
+        <range_axis_name>Main Range Axis</range_axis_name>
+        <color>-65281</color>
+        <draw_type>steps</draw_type>
+        <draw_width>1</draw_width>
+        <visibility>true</visibility>
+    </pv>
+</AVConfiguration>

--- a/trace/mixins/file_io.py
+++ b/trace/mixins/file_io.py
@@ -45,7 +45,8 @@ class FileIOMixin:
                 self,
                 "Open Trace",
                 str(self.io_path),
-                "Trace Save File (*.trc);;Java Archive Viewer (*.xml);;All Files (*)",
+                "Trace Save File (*.trc *.xml *.stp);;Java Archive Viewer (*.xml);;"
+                + "StripTool File (*.stp);;All Files (*)",
             )
         file_name = Path(file_name)
         if not file_name.is_file():

--- a/trace/mixins/file_io.py
+++ b/trace/mixins/file_io.py
@@ -57,8 +57,6 @@ class FileIOMixin:
         try:
             logger.debug(f"Attempting to import file: {file_name}")
             file_data = self.converter.import_file(file_name)
-            if self.converter.import_is_xml():
-                file_data = self.converter.convert_data(file_data)
             self.io_path = file_name.parent
         except FileNotFoundError as e:
             logger.error(e)

--- a/trace/mixins/plot_config.py
+++ b/trace/mixins/plot_config.py
@@ -44,19 +44,19 @@ class PlotConfigMixin:
         if "title" in config:
             self.ui.plot_title_edit.setText(config["title"])
         if "xGrid" in config:
-            self.ui.x_grid_chckbx.setChecked(config["xGrid"])
+            self.ui.x_grid_chckbx.setChecked(bool(config["xGrid"]))
         if "yGrid" in config:
-            self.ui.y_grid_chckbx.setChecked(config["yGrid"])
+            self.ui.y_grid_chckbx.setChecked(bool(config["yGrid"]))
         if "opacity" in config:
             self.ui.opacity_sldr.setValue(config["opacity"])
         if "backgroundColor" in config:
             self.background_color_button.color = QColor(config["backgroundColor"])
         if "legend" in config:
-            self.ui.legend_chckbx.setChecked(config["legend"])
+            self.ui.legend_chckbx.setChecked(bool(config["legend"]))
         if "mouseMode" in config:
             self.ui.mouse_mode_cmbbx.setCurrentIndex(int(config["mouseMode"] / 3))
         if "crosshair" in config:
-            self.ui.crosshair_chckbx.setChecked(config["crosshair"])
+            self.ui.crosshair_chckbx.setChecked(bool(config["crosshair"]))
         if "refreshInterval" in config:
             self.ui.refresh_interval_spnbx.setValue(config["refreshInterval"])
 

--- a/trace/trace_file_convert.py
+++ b/trace/trace_file_convert.py
@@ -6,7 +6,7 @@ import logging
 import xml.etree.ElementTree as ET
 from os import path, getenv
 from re import compile
-from typing import Dict, Union
+from typing import Dict, List, Union
 from pathlib import Path
 from argparse import Action, Namespace, ArgumentParser
 from datetime import datetime
@@ -50,6 +50,11 @@ class TraceFileConverter:
         with self.input_file.open() as f:
             return f.readline().startswith("<?xml")
 
+    def import_is_stp(self):
+        """Helper function to determine if the import file is a StripTool file."""
+        with self.input_file.open() as f:
+            return f.readline().startswith("StripConfig")
+
     def import_file(self, file_name: Union[str, Path] = None) -> Dict:
         """Import Archive Viewer save data from the provided file. The file
         should be one of two types: '.trc' or '.xml'. The data is returned as
@@ -70,15 +75,16 @@ class TraceFileConverter:
         if not self.input_file.is_file():
             raise FileNotFoundError(f"Data file not found: {self.input_file}")
 
-        with self.input_file.open() as f:
-            is_xml = f.readline().startswith("<?xml")
-
         text = self.input_file.read_text()
-        if is_xml:
+        if self.import_is_xml():
             etree = ET.ElementTree(ET.fromstring(text))
             self.stored_data = self.xml_to_dict(etree)
             if not (self.stored_data["pv"] or self.stored_data["formula"]):
                 raise FileNotFoundError(f"Incorrect input file format: {self.input_file}")
+            self.stored_data = self.convert_xml_data(self.stored_data)
+        elif self.import_is_stp():
+            self.stored_data = self.stp_to_dict(text)
+            self.stored_data = self.convert_stp_data(self.stored_data)
         else:
             self.stored_data = json.loads(text)
             if not self.stored_data["curves"]:
@@ -131,10 +137,10 @@ class TraceFileConverter:
         with open(self.output_file, "w") as f:
             json.dump(output_data, f, indent=4)
 
-    def convert_data(self, data_in: Dict = {}) -> Dict:
+    def convert_xml_data(self, data_in: Dict = {}) -> Dict:
         """Convert the inputted data from being formatted for the Java Archive
-        Viewer to a format used by the PyDM Archive Viewer. This is accomplished
-        by converting one dictionary structure to another.
+        Viewer to a format used by trace. This is accomplished by converting one
+        dictionary structure to another.
 
         Parameters
         ----------
@@ -144,7 +150,7 @@ class TraceFileConverter:
         Returns
         -------
         dict
-            The converted data in a format that can be used by the PyDM Archive Viewer
+            The converted data in a format that can be used by trace
         """
         if not data_in:
             data_in = self.stored_data
@@ -215,6 +221,73 @@ class TraceFileConverter:
 
         self.stored_data = converted_data
         return self.stored_data
+
+    def convert_stp_data(self, data_in: Dict = {}) -> Dict:
+        """Convert the inputted data from a format used by StripTool to a format
+        used by Trace. This is accomplished by converting one dictionary structure
+        to another.
+
+        Parameters
+        ----------
+        data_in : dict, optional
+            The input data to be converted, by default uses previously imported data
+
+        Returns
+        -------
+        dict
+            The converted data in a format that can be used by trace
+        """
+        if not data_in:
+            data_in = self.stored_data
+
+        converted = {"archiver_url": getenv("PYDM_ARCHIVER_URL")}
+
+        # Convert all colors to a usable format
+        for k, v in data_in["Color"].items():
+            color = self.xColor_to_qColor(*v)
+            data_in["Color"][k] = color.name()
+
+        # Convert plot config
+        converted["plot"] = {}
+        converted["plot"]["xGrid"] = bool(data_in["Option"]["GridXon"])
+        converted["plot"]["yGrid"] = bool(data_in["Option"]["GridYon"])
+        converted["plot"]["backgroundColor"] = data_in["Color"]["Background"]
+
+        # Convert time_axis
+        converted["time_axis"] = {"name": "Main Time Axis", "location": "bottom"}
+        converted["time_axis"]["start"] = "-" + data_in["Time"]["Timespan"] + "s"
+        converted["time_axis"]["end"] = "now"
+
+        # Convert y-axes
+        converted["y-axes"] = []
+        all_units = {c["Units"] for c in data_in["Curve"].values()}
+        for unit in all_units:
+            axis = {"name": unit, "label": unit, "orientation": "left"}
+            converted["y-axes"].append(axis)
+
+        # Convert curves
+        converted["curves"] = []
+        converted["formula"] = []
+        for ind, data in data_in["Curve"].items():
+            curve = {}
+            curve["name"] = data["Name"]
+            curve["channel"] = data["Name"]
+
+            color_key = f"Color{int(ind) + 1}"
+            curve["color"] = data_in["Color"][color_key]
+            curve["thresholdColor"] = data_in["Color"][color_key]
+
+            # Set logMode for curve's associated axis
+            curve["yAxisName"] = data["Units"]
+            if data["Scale"] == "1":
+                for ax in converted["y-axes"]:
+                    if ax["name"] == data["Units"]:
+                        ax["logMode"] = True
+                        break
+
+            converted["curves"].append(curve)
+
+        return converted
 
     @classmethod
     def reformat_date(cls, input_str: str) -> str:
@@ -292,6 +365,38 @@ class TraceFileConverter:
         return data_dict
 
     @staticmethod
+    def stp_to_dict(stp_text: str) -> Dict:
+        """Convert the StripTool file's text into a dictionary.
+
+        Parameters
+        ----------
+        stp_text : str
+            The full file text from the StripTool file
+
+        Returns
+        -------
+        dict
+            The data in a dictionary format
+        """
+        extracted_data = {}
+
+        for line in stp_text.splitlines():
+            line_split = line.split()
+            key = line_split[0].removeprefix("Strip.")
+            val = line_split[1:] if len(line_split) > 2 else line_split[1]
+
+            # Find which child dictionary should contain the key-value pair
+            data_loc = extracted_data
+            key_split = key.split(".")
+            for k in key_split[:-1]:
+                if k not in data_loc:
+                    data_loc[k] = {}
+                data_loc = data_loc[k]
+            data_loc[key_split[-1]] = val
+
+        return extracted_data
+
+    @staticmethod
     def get_plot_data(plot: PyDMTimePlot) -> dict:
         """Extract plot, axis, and curve data from a PyDMTimePlot object
 
@@ -365,6 +470,26 @@ class TraceFileConverter:
         return QColor(srgb)
 
     @staticmethod
+    def xColor_to_qColor(rgb: List[str]) -> QColor:
+        """Convert XColor values into QColors. Colors in StripTool files (*.stp)
+        are saved as XColors.
+
+        Parameters
+        ----------
+        rgb : list(str)
+            A list of strings containing the rgb values (0 <= rgb < 0xFFFF)
+
+        Returns
+        -------
+        QColor
+            A QColor object storing the color described in the string
+        """
+        for i in range(3):
+            rgb[i] = int(rgb[i]) // 256
+
+        return QColor(*rgb)
+
+    @staticmethod
     def remove_null_values(dict_in: dict) -> dict:
         """Remove all key-value pairs from a given dictionary where the value is None
 
@@ -391,7 +516,7 @@ def main(input_file: Path = None, output_file: Path = None, overwrite: bool = Fa
         raise FileNotFoundError("Input file not provided")
     elif not input_file.is_file():
         raise FileNotFoundError(f"Data file not found: {input_file}")
-    elif not input_file.match("*.xml"):
+    elif not (input_file.match("*.xml") or input_file.match("*.stp")):
         raise FileNotFoundError(f"Incorrect input file format: {input_file}")
 
     # Check that the output file is usable
@@ -410,7 +535,6 @@ def main(input_file: Path = None, output_file: Path = None, overwrite: bool = Fa
     converter = TraceFileConverter()
 
     converter.import_file(input_file)
-    converter.convert_data()
     converter.export_file(output_file)
 
     # Remove the input file if requested


### PR DESCRIPTION
This PR adds the ability to import and convert StripTool files (*.stp) to Trace files (*.trc). This works the same as importing and converting the Java-based Archive Viewer save files. It should be very straight forward.

Minor Changes:
- When importing files, the file conversion is handled by the converter object rather than needing to be called separately. This let's the converter handle converting xml data vs stp data. Just faster/easier.
- Removed context menu from the plot. Right clicking is now a panning tool.

Bug Fix:
Fixed a bug when importing Plot Configuration options. Functions being called expected bools, but were given Truey/Falsey values. Just converted the values to bools to fix this issue.

Docs:
Added importing StripTool to documentation. Also included example Archive Viewer and StripTool save files for users to try importing those. Cause why not ¯\\\_(ツ)\_/¯ ??