### PR TITLE
DOC: One More Change to README and Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,8 +1,7 @@
 name: Bug report
 description: Report an issue or bug with the project.
 title: "[BUG] - "
-labels:
-  - bug
+labels: ["bug"]
 
 body:
   - type: markdown
@@ -16,6 +15,8 @@ body:
       label: Describe the bug
       description: A clear and concise description of what the bug is.
       placeholder: The bug occurs when...
+    validations:
+      required: true
 
   - type: textarea
     id: expected_behavior
@@ -23,6 +24,8 @@ body:
       label: Expected behavior
       description: A clear and concise description of what you expected to happen.
       placeholder: I expected...
+    validations:
+      required: true
 
   - type: textarea
     id: steps_to_reproduce
@@ -34,6 +37,8 @@ body:
         2. Click on...
         3. Scroll down to...
         4. See error
+    validations:
+      required: true
 
   - type: textarea
     id: possible_solution
@@ -41,6 +46,8 @@ body:
       label: Possible solution (optional)
       description: Suggest a fix or reason for the bug, if you have any.
       placeholder: A possible solution could be...
+    validations:
+      required: false
 
   - type: input
     id: platform
@@ -48,9 +55,11 @@ body:
       label: My platform
       description: Provide details about your system.
       placeholder: |
-        * OS Version: ...
-        * Python Version: ...
-        * Package Versions: ...
+        OS Version: ...
+        Python Version: ...
+        Package Versions: ...
+    validations:
+      required: false
 
   - type: textarea
     id: additional_context
@@ -58,3 +67,5 @@ body:
       label: Additional context
       description: Add any other context, links, or information about the bug.
       placeholder: Include logs, screenshots, or other details here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,8 +1,7 @@
 name: Feature request
 description: Suggest a new feature or enhancement for the project.
 title: "[FEATURE] - "
-labels:
-  - enhancement
+labels: ["enhancement"]
 
 body:
   - type: markdown
@@ -16,6 +15,8 @@ body:
       label: What's the problem this feature will solve?
       description: A clear and concise description of the problem or pain point.
       placeholder: This feature would solve...
+    validations:
+      required: true
 
   - type: textarea
     id: solution
@@ -23,6 +24,8 @@ body:
       label: Describe the solution you'd like
       description: A clear and concise description of what you want to happen.
       placeholder: The ideal solution would be...
+    validations:
+      required: true
 
   - type: textarea
     id: additional_context
@@ -30,3 +33,5 @@ body:
       label: Additional context
       description: Add any other context, links, or resources to support your feature request.
       placeholder: Include any relevant links, screenshots, or references here.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ trace is an PyDM-based application developed at SLAC National Accelerator Labora
 
 For more information and a how to guide on trace see [the project's website](https://slaclab.github.io/trace/)
 <p align="center">
-  <a href="https://github.com/slaclab/trace/issues/new?template=bug-report.yml">Report bug</a>
+  <a href="https://github.com/slaclab/trace/issues/new?labels=bug&projects=&template=bug-report.yml&title=%5BBUG%5D+-+">Report bug</a>
   ·
-  <a href="https://github.com/slaclab/trace/issues/new?template=feature-request.yml">Request feature</a>
+  <a href="https://github.com/slaclab/trace/issues/new?labels=enhancement&projects=&template=feature-request.yml&title=%5BFEATURE%5D+-+">Request feature</a>
 
 </p>
 


### PR DESCRIPTION
Fix the links to the issue templates in the README so they have labels and titles. Add validation to issue templates so that some fields are required. This is the description fields, steps to reproduce, and what the user would like to see.