### PR TITLE
FIX: Remove Duplicate Logging

### DIFF
--- a/trace/trace_file_convert.py
+++ b/trace/trace_file_convert.py
@@ -16,10 +16,8 @@ from qtpy.QtGui import QColor
 
 from pydm.widgets.timeplot import PyDMTimePlot
 
-if __name__ in logging.Logger.manager.loggerDict:
-    logger = logging.getLogger(__name__)
-else:
-    logger = logging.getLogger("")
+logger = logging.getLogger("")
+if not logger.hasHandlers():
     handler = logging.StreamHandler()
     formatter = logging.Formatter("[%(asctime)s] [%(levelname)-8s] - %(message)s")
     handler.setFormatter(formatter)


### PR DESCRIPTION
I found where the duplicate logging was coming from. A second logger was always being created in `trace_file_convert.py` when it should have only been creating a logger if one didn't already exist.

Solution:
Get the logger (same name PyDM uses) and check if it has handlers. If handlers don't exist, then add them.