### PR TITLE
ENH/FIX: Minor UI Fixes/Changes

### DIFF
--- a/trace/main.py
+++ b/trace/main.py
@@ -93,7 +93,7 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         """Set footer information for application. Includes logging, nodename,
         username, PID, git version, Archiver URL, and current datetime
         """
-        self.logging_handler = LoggingHandler(self.ui.ftr_logging_lbl)
+        self.logging_handler = LoggingHandler(self.ui.logger_lbl)
         logger.addHandler(self.logging_handler)
         logger.setLevel("NOTSET")
 

--- a/trace/main.py
+++ b/trace/main.py
@@ -38,9 +38,9 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         self.axis_table_model.reset_everything.connect(self.resetPlot)
         # Create reference dict for timespan_btns button group
         self.button_spans = {
-            self.ui.half_min_scale_btn: 30,
             self.ui.min_scale_btn: 60,
             self.ui.hour_scale_btn: 3600,
+            self.ui.day_scale_btn: 86400,
             self.ui.week_scale_btn: 604800,
             self.ui.month_scale_btn: 2628300,
             self.ui.cursor_scale_btn: -1,

--- a/trace/main.ui
+++ b/trace/main.ui
@@ -38,25 +38,6 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="half_min_scale_btn">
-       <property name="maximumSize">
-        <size>
-         <width>40</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>30s</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">timespan_btns</string>
-       </attribute>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="min_scale_btn">
        <property name="maximumSize">
         <size>
@@ -90,6 +71,25 @@
         <bool>true</bool>
        </property>
        <property name="checked">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">timespan_btns</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="day_scale_btn">
+       <property name="maximumSize">
+        <size>
+         <width>40</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>1d</string>
+       </property>
+       <property name="checkable">
         <bool>true</bool>
        </property>
        <attribute name="buttonGroup">

--- a/trace/main.ui
+++ b/trace/main.ui
@@ -434,6 +434,52 @@
              </layout>
             </item>
             <item>
+             <layout class="QHBoxLayout" name="opacity_lyt">
+              <item>
+               <widget class="QLabel" name="opacity_lbl">
+                <property name="text">
+                 <string>Gridline Opacity</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSlider" name="opacity_sldr">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+                <property name="singleStep">
+                 <number>1</number>
+                </property>
+                <property name="value">
+                 <number>127</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="opacity_spcr">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
              <layout class="QHBoxLayout" name="legend_lyt">
               <item>
                <widget class="QLabel" name="legend_lbl">
@@ -587,52 +633,6 @@
               </item>
               <item>
                <spacer name="mouse_mode_spcr">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <layout class="QHBoxLayout" name="opacity_lyt">
-              <item>
-               <widget class="QLabel" name="opacity_lbl">
-                <property name="text">
-                 <string>Opacity</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QSlider" name="opacity_sldr">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="maximum">
-                 <number>255</number>
-                </property>
-                <property name="singleStep">
-                 <number>1</number>
-                </property>
-                <property name="value">
-                 <number>127</number>
-                </property>
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="opacity_spcr">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>

--- a/trace/main.ui
+++ b/trace/main.ui
@@ -92,9 +92,6 @@
        <property name="checkable">
         <bool>true</bool>
        </property>
-       <attribute name="buttonGroup">
-        <string notr="true">timespan_btns</string>
-       </attribute>
       </widget>
      </item>
      <item>
@@ -158,53 +155,48 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <widget class="QTabWidget" name="display_tabs">
-      <property name="currentIndex">
-       <number>0</number>
+     <widget class="QFrame" name="plot_frame">
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
       </property>
-      <widget class="QWidget" name="time_plot_tab">
-       <attribute name="title">
-        <string>Time Plots</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="PyDMArchiverTimePlot" name="main_plot">
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="backgroundColor">
-           <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="axisColor">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="bufferSize">
-           <number>5000</number>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="PyDMArchiverTimePlot" name="main_plot">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="backgroundColor">
+          <color>
+           <red>255</red>
+           <green>255</green>
+           <blue>255</blue>
+          </color>
+         </property>
+         <property name="axisColor">
+          <color>
+           <red>0</red>
+           <green>0</green>
+           <blue>0</blue>
+          </color>
+         </property>
+         <property name="bufferSize">
+          <number>5000</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
      <widget class="QTabWidget" name="properties_tabs">
       <property name="currentIndex">
@@ -333,7 +325,7 @@
              <x>0</x>
              <y>0</y>
              <width>1146</width>
-             <height>435</height>
+             <height>416</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/trace/main.ui
+++ b/trace/main.ui
@@ -545,24 +545,27 @@
              <layout class="QHBoxLayout" name="refresh_interval_lyt">
               <item>
                <widget class="QLabel" name="refresh_interval_lbl">
+                <property name="toolTip">
+                 <string>seconds</string>
+                </property>
                 <property name="text">
-                 <string>Autoscroll refresh rate</string>
+                 <string>Autoscroll refresh interval</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QDoubleSpinBox" name="refresh_interval_spnbx">
-                <property name="decimals">
-                 <number>1</number>
+               <widget class="QSpinBox" name="refresh_interval_spnbx">
+                <property name="toolTip">
+                 <string>seconds</string>
                 </property>
                 <property name="minimum">
-                 <double>0.100000000000000</double>
+                 <number>1</number>
                 </property>
                 <property name="maximum">
-                 <double>60.000000000000000</double>
+                 <number>60</number>
                 </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
+                <property name="value">
+                 <number>5</number>
                 </property>
                </widget>
               </item>

--- a/trace/main.ui
+++ b/trace/main.ui
@@ -333,7 +333,7 @@
              <x>0</x>
              <y>0</y>
              <width>1146</width>
-             <height>413</height>
+             <height>435</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -696,229 +696,232 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="logger_tab">
+       <attribute name="title">
+        <string>Logger</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <widget class="QLabel" name="logger_lbl">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </widget>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="ftr_logging_lyt">
+    <layout class="QHBoxLayout" name="ftr_lyt">
      <item>
-      <widget class="QLabel" name="ftr_logging_lbl">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      <widget class="QLabel" name="ftr_ver_lbl">
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>Trace Version</string>
        </property>
        <property name="text">
-        <string/>
+        <string>&lt;version_tag&gt;</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignHCenter|Qt::AlignTop</set>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
+        <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
        </property>
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="ftr_lyt">
-       <item>
-        <widget class="QLabel" name="ftr_ver_lbl">
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string>Trace Version</string>
-         </property>
-         <property name="text">
-          <string>&lt;version_tag&gt;</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="ftr_sep_1_lbl">
-         <property name="font">
-          <font>
-           <pointsize>12</pointsize>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>|</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="ftr_node_lbl">
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string>nodename</string>
-         </property>
-         <property name="text">
-          <string>&lt;nodename&gt;</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="ftr_sep_2_lbl">
-         <property name="font">
-          <font>
-           <pointsize>12</pointsize>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>|</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="ftr_user_lbl">
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string>user</string>
-         </property>
-         <property name="text">
-          <string>&lt;user&gt;</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="ftr_sep_3_lbl">
-         <property name="font">
-          <font>
-           <pointsize>12</pointsize>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>|</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="ftr_pid_lbl">
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string>PID</string>
-         </property>
-         <property name="text">
-          <string>&lt;PID&gt;</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="ftr_sep_4_lbl">
-         <property name="font">
-          <font>
-           <pointsize>12</pointsize>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>|</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="ftr_url_lbl">
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string>Archiver URL</string>
-         </property>
-         <property name="text">
-          <string>&lt;PYDM_ARCHIVER_URL&gt;</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="ftr_spcr">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::MinimumExpanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="PyDMLabel" name="ftr_time_lbl">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="precision" stdset="0">
-          <number>0</number>
-         </property>
-         <property name="showUnits" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="precisionFromPV" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="alarmSensitiveContent" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="alarmSensitiveBorder" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="PyDMToolTip" stdset="0">
-          <string>Current Datetime</string>
-         </property>
-         <property name="channel" stdset="0">
-          <string/>
-         </property>
-         <property name="enableRichText" stdset="0">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      <widget class="QLabel" name="ftr_sep_1_lbl">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>|</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="ftr_node_lbl">
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>nodename</string>
+       </property>
+       <property name="text">
+        <string>&lt;nodename&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="ftr_sep_2_lbl">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>|</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="ftr_user_lbl">
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>user</string>
+       </property>
+       <property name="text">
+        <string>&lt;user&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="ftr_sep_3_lbl">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>|</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="ftr_pid_lbl">
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>PID</string>
+       </property>
+       <property name="text">
+        <string>&lt;PID&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="ftr_sep_4_lbl">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>|</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="ftr_url_lbl">
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>Archiver URL</string>
+       </property>
+       <property name="text">
+        <string>&lt;PYDM_ARCHIVER_URL&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="ftr_spcr">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::MinimumExpanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="ftr_time_lbl">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string>Current Datetime</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+       <property name="enableRichText" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/trace/mixins/plot_config.py
+++ b/trace/mixins/plot_config.py
@@ -28,7 +28,6 @@ class PlotConfigMixin:
         self.ui.background_color_lyt.insertWidget(1, self.background_color_button)
         self.background_color_button.color_changed.connect(self.plot.setBackgroundColor)
 
-        self.ui.refresh_interval_spnbx.setValue(5)
         self.ui.refresh_interval_spnbx.valueChanged.connect(lambda interval: self.autoScroll(enable=True))
 
         self.ui.legend_chckbx.stateChanged.connect(self.plot.setShowLegend)

--- a/trace/mixins/plot_config.py
+++ b/trace/mixins/plot_config.py
@@ -41,7 +41,7 @@ class PlotConfigMixin:
         the import file out. For each config preset, set the widgets to match the value, which will
         send signals out that will actually cause the plot to change"""
         if "title" in config:
-            self.ui.plot_title_edit.setText(config["title"])
+            self.ui.plot_title_edit.setText(str(config["title"]))
         if "xGrid" in config:
             self.ui.x_grid_chckbx.setChecked(bool(config["xGrid"]))
         if "yGrid" in config:
@@ -57,7 +57,7 @@ class PlotConfigMixin:
         if "crosshair" in config:
             self.ui.crosshair_chckbx.setChecked(bool(config["crosshair"]))
         if "refreshInterval" in config:
-            self.ui.refresh_interval_spnbx.setValue(config["refreshInterval"])
+            self.ui.refresh_interval_spnbx.setValue(int(config["refreshInterval"]))
 
     @Slot(int)
     def set_font_size(self, size: int):

--- a/trace/tests/test_data/test_file.trc
+++ b/trace/tests/test_data/test_file.trc
@@ -1,7 +1,7 @@
 {
     "archiver_url": "http://lcls-archapp.slac.stanford.edu",
     "plot": {
-        "refreshInterval": 0.5,
+        "refreshInterval": 4,
         "title": "Test Plot Title",
         "xGrid": true,
         "yGrid": false,

--- a/trace/tests/test_mixins/test_plot_config.py
+++ b/trace/tests/test_mixins/test_plot_config.py
@@ -99,7 +99,7 @@ def test_auto_scroll(qtrace, test_value):
         return
 
     # Constrain test value to be between expected min and max
-    constrained_value = min(max(test_value * 1000, 100), 60000)
+    constrained_value = min(max(test_value * 1000, 1000), 60000)
     qtrace.ui.refresh_interval_spnbx.setValue(test_value)
     assert qtrace.plot.auto_scroll_timer.interval() == constrained_value
     assert qtrace.plot.auto_scroll_timer.isActive()

--- a/trace/widgets/item_delegates.py
+++ b/trace/widgets/item_delegates.py
@@ -387,7 +387,7 @@ class ScientificNotationDelegate(EditorDelegate):
             if value is None:
                 value = self.range[0]
 
-            rx = QRegExp(r"^[+-]?\d*(?:\.\d*(?:[eE][+-]?\d+)?)?$")
+            rx = QRegExp(r"^[+-]?\d*(?:\.\d*)?(?:[eE][+-]?\d+)?$")
             validator = QRegExpValidator(rx, parent)
 
             editor = QLineEdit(parent)

--- a/trace/widgets/item_delegates.py
+++ b/trace/widgets/item_delegates.py
@@ -387,7 +387,7 @@ class ScientificNotationDelegate(EditorDelegate):
             if value is None:
                 value = self.range[0]
 
-            rx = QRegExp(r"^[+-]?\d*(?:\.\d*)?(?:[eE][+-]?\d+)?$")
+            rx = QRegExp(r"^[+-]?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?$")
             validator = QRegExpValidator(rx, parent)
 
             editor = QLineEdit(parent)


### PR DESCRIPTION
Changes in PR ([Jira issue](https://jira.slac.stanford.edu/secure/RapidBoard.jspa?projectKey=TRC&rapidView=207)):
- Scientific Notation Validation should allow numbers in format '1e5' (TRC-68)
- Remove main_plot from the Time Plots tabwidget (TRC-71)
- Replace the 30s quick range selection button with 1d (TRC-72)
- Auto-scroll refresh rate spinbox should be an int instead of a float (TRC-73)
- Opacity slider should be more clear that it is gridline opacity (TRC-74)
- Move the logger from the footer into a new tab in the properties section (TRC-75)

