### PR TITLE
FIX: Fixing input_file argument for trace (TRC-66)

### DIFF
--- a/trace/main.py
+++ b/trace/main.py
@@ -142,14 +142,13 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
             "-i",
             "--input_file",
             action=PathAction,
-            type=str,
-            default="",
+            nargs="?",
+            default=[],
             help="Absolute file path to import from\nAlternatively can be provided as INPUT_FILE macro",
         )
         trace_parser.add_argument(
             "-p",
             "--pvs",
-            type=str,
             nargs="*",
             default=[],
             help="Space-separated list of PVs to show on startup\nFormulas should be passed without spaces: "
@@ -158,7 +157,6 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         trace_parser.add_argument(
             "-m",
             "--macro",
-            type=str,
             default="",
             help="Mimic PyDM macro replacements to use. Should be in JSON object format."
             + "\nJSON Formatting Reminder:"
@@ -182,8 +180,11 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
             macros.update(**parsed_macros)
 
         # Get the file to import from if one is provided. Prioritize args over macro
-        input_file = trace_args.input_file
-        if not input_file and "INPUT_FILE" in macros:
+        input_file = ""
+        if trace_args.input_file:
+            # Need to unpack as PathAction returns a list
+            input_file = trace_args.input_file[0]
+        elif "INPUT_FILE" in macros:
             input_file = macros["INPUT_FILE"]
 
         # Get the list of PVs to show on startup

--- a/trace/trace_file_convert.py
+++ b/trace/trace_file_convert.py
@@ -604,8 +604,13 @@ def main(input_file: List[Path] = None, output_file: List[Path] = None, overwrit
 
 
 class PathAction(Action):
-    def __call__(self, parser: ArgumentParser, namespace: Namespace, values: str, option_string: str = None) -> None:
+    def __call__(
+        self, parser: ArgumentParser, namespace: Namespace, values: Union[str, List], option_string: str = None
+    ) -> None:
         """Convert filepath string from argument into  a pathlib.Path object"""
+        if isinstance(values, str):
+            values = [values]
+
         new_paths = []
         for file_path in values:
             new_path = path.expandvars(file_path)


### PR DESCRIPTION
Fixing a bug caused by batch conversion feature.

PathAction was taking in a list or a string, but only treating it as a list. This resulted in it creating a Path object for every character in the provided string. My solution is to check if the given value is a string, and if it is, then PathAction wraps it in a list first.

The second issue PathAction had, is that it only ever returned a list. So FileIOMixin.save_file_import would throw an error because it expected a Path object. My solution is to unpack the list before calling save_file_import.