### PR TITLE
ENH: Combine Y-axis Name & Label Columns

### DIFF
--- a/trace/mixins/axis_table.py
+++ b/trace/mixins/axis_table.py
@@ -18,6 +18,9 @@ class AxisTableMixin:
         self.axis_table_model = ArchiverAxisModel(self.ui.main_plot, self)
         self.ui.time_axis_tbl.setModel(self.axis_table_model)
 
+        label_col = self.axis_table_model.getColumnIndex("Y-Axis Label")
+        self.ui.time_axis_tbl.hideColumn(label_col)
+
         hdr = self.ui.time_axis_tbl.horizontalHeader()
         hdr.setSectionResizeMode(QHeaderView.Stretch)
         del_col = self.axis_table_model.getColumnIndex("")

--- a/trace/table_models/axis_model.py
+++ b/trace/table_models/axis_model.py
@@ -89,6 +89,12 @@ class ArchiverAxisModel(BasePlotAxesModel):
         elif role == Qt.CheckStateRole and index.column() in self.checkable_col:
             return super().setData(index, value, Qt.EditRole)
         elif index.column() not in self.checkable_col:
+            # Changes to axis' name should change axis' label as well
+            if self._column_names[index.column()] == "Y-Axis Name":
+                label_col = self.getColumnIndex("Y-Axis Label")
+                label_index = self.index(index.row(), label_col)
+                self.setData(label_index, value, role)
+
             return super().setData(index, value, role)
         return None
 


### PR DESCRIPTION
[Related issue](https://jira.slac.stanford.edu/secure/RapidBoard.jspa?rapidView=207&projectKey=TRC&view=detail&selectedIssue=TRC-79#)
 
There is no need for the name and the label to be different for y-axes. Combining the columns so that editing the name also edits the label.

This will fix some confusion that users have had.