### PR TITLE
TST/FIX: Add Tests for Models & Widgets

### DIFF
--- a/trace/table_models/axis_model.py
+++ b/trace/table_models/axis_model.py
@@ -140,6 +140,7 @@ class ArchiverAxisModel(BasePlotAxesModel):
         }
         cleaned_axes = []
         for a in axes:
+            # The bare requirements for a new axis
             clean_a = {
                 "name": f"Axis {len(cleaned_axes) + 1}",
                 "orientation": "left",
@@ -154,12 +155,6 @@ class ArchiverAxisModel(BasePlotAxesModel):
                 else:
                     clean_a[k] = a[k]
             cleaned_axes.append(clean_a)
-        clean_a = {
-            "name": f"Axis {len(cleaned_axes) + 1}",
-            "orientation": "left",
-            "label": f"Axis {len(cleaned_axes) + 1}",
-        }
-        cleaned_axes.append(clean_a)
         logger.debug("Clearing axes model")
         self.beginResetModel()
         self._plot.clearAxes()

--- a/trace/table_models/axis_model.py
+++ b/trace/table_models/axis_model.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List
 
-from qtpy.QtCore import Qt, Signal, QVariant, QModelIndex, QPersistentModelIndex
+from qtpy.QtCore import Qt, Signal, QModelIndex, QPersistentModelIndex
 
 from pydm.widgets.baseplot import BasePlot, BasePlotAxisItem
 from pydm.widgets.axis_table_model import BasePlotAxesModel
@@ -38,6 +38,9 @@ class ArchiverAxisModel(BasePlotAxesModel):
 
     def flags(self, index: QModelIndex) -> Qt.ItemFlags:
         """Return flags that determine how users can interact with the items in the table"""
+        if not index.isValid():
+            return Qt.NoItemFlags
+
         flags = super().flags(index)
         if index.column() in self.checkable_col:
             flags = Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsSelectable
@@ -56,7 +59,7 @@ class ArchiverAxisModel(BasePlotAxesModel):
             needs, by default Qt.DisplayRole
         """
         if not index.isValid():
-            return QVariant()
+            return None
         elif role == Qt.CheckStateRole and self._column_names[index.column()] == "Hidden":
             return Qt.Unchecked if self.plot._axes[index.row()].isVisible() else Qt.Checked
         elif role == Qt.CheckStateRole and index.column() in self.checkable_col:
@@ -81,7 +84,7 @@ class ArchiverAxisModel(BasePlotAxesModel):
         """
         logger.debug(f"Setting {self._column_names[index.column()]} on axis {index.siblingAtColumn(0).data()}")
         if not index.isValid():
-            return QVariant()
+            return None
         # Specifically the Hidden column must be affected in axis_model as opposed to elsewhere
         elif role == Qt.CheckStateRole and self._column_names[index.column()] == "Hidden":
             self.plot._axes[index.row()].setHidden(bool(value))

--- a/trace/table_models/curve_model.py
+++ b/trace/table_models/curve_model.py
@@ -172,7 +172,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
                 try:
                     ret_code = self.replaceToFormula(index=index, formula=value)
                 except (SyntaxError, ValueError) as e:
-                    logger.error(e)
+                    logger.error(str(e))
                     return False
             elif value_is_formula and curve_is_formula:
                 try:
@@ -180,7 +180,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
                     curve.formula = value
                     curve.pvs = pv_dict
                 except (SyntaxError, ValueError) as e:
-                    logger.error(e)
+                    logger.error(str(e))
                     return False
             elif not value_is_formula:
                 if not curve_is_formula:
@@ -604,6 +604,8 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             The curve's live connection status.
         """
         curve = self.sender()
+        if not isinstance(curve, (ArchivePlotCurveItem, FormulaCurveItem)):
+            return
 
         if connection:
             self._invalid_live_channels.discard(curve)

--- a/trace/table_models/curve_model.py
+++ b/trace/table_models/curve_model.py
@@ -240,8 +240,10 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             Returns the model's default flags, and if the column is Live Data or
             Archive Data, then may also disable the index depending on channel status.
         """
-        flags = super().flags(index)
+        if not index.isValid():
+            return Qt.NoItemFlags
 
+        flags = super().flags(index)
         col_name = self._column_names[index.column()]
         if col_name in ("Live Data", "Archive Data"):
             curve = self.curve_at_index(index)

--- a/trace/table_models/curve_model.py
+++ b/trace/table_models/curve_model.py
@@ -282,17 +282,16 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         self._plot.addYChannel(y_channel=address, name=name, color=color, useArchiveData=True, yAxisName=y_axis.name)
         self.endInsertRows()
 
-        new_curve = self._plot._curves[-1]
+        new_curve = self.curve_at_index(-1)
         new_curve.hide()
         if self.rowCount() != 1:
             logger.debug("Hide blank Y-axis")
             self._axis_model.plot.plotItem.axes[y_axis.name]["item"].hide()
         new_curve.unitSignal.connect(self.setAxis)
-        logger.debug("Finished adding new empty curve to plot")
 
-        curve = self.curve_at_index(-1)
-        curve.live_channel_connection.connect(self.live_connection_slot)
-        curve.archive_channel_connection.connect(self.archive_connection_slot)
+        new_curve.live_channel_connection.connect(self.live_connection_slot)
+        new_curve.archive_channel_connection.connect(self.archive_connection_slot)
+        logger.debug("Finished adding new empty curve to plot")
 
     def set_model_curves(self, curves: List[Dict] = []) -> None:
         """Reset the model to only contain the list of given curves.

--- a/trace/tests/conftest.py
+++ b/trace/tests/conftest.py
@@ -59,7 +59,9 @@ def qapp(qapp_args):
     if "pytest-qt-qapp" == qapp_args[0]:
         qapp_args.remove("pytest-qt-qapp")
 
-    yield PyDMApplication(use_main_window=False, *qapp_args)
+    app = PyDMApplication(use_main_window=False, *qapp_args)
+    yield app
+    app.quit()
 
 
 @pytest.fixture
@@ -75,8 +77,11 @@ def qtrace(qapp):
 
     # updateXAxis would be called on application render; necessary for testing X-Axis
     trace.ui.main_plot.updateXAxis(True)
-
     yield trace
+
+    trace.close()
+    qapp.processEvents()
+    del trace
 
 
 @pytest.fixture

--- a/trace/tests/test_data/test_file.trc
+++ b/trace/tests/test_data/test_file.trc
@@ -25,6 +25,14 @@
             "maxRange": 1.04,
             "autoRange": true,
             "logMode": false
+        },
+        {
+            "name": "FOO Axis",
+            "orientation": "right",
+            "minRange": -15,
+            "maxRange": 15,
+            "autoRange": false,
+            "logMode": true
         }
     ],
     "curves": [

--- a/trace/tests/test_mixins/test_traces_table.py
+++ b/trace/tests/test_mixins/test_traces_table.py
@@ -1,3 +1,8 @@
+from json import loads
+from unittest import mock
+
+import pytest
+
 from widgets.item_delegates import (
     ComboBoxDelegate,
     DeleteRowDelegate,
@@ -20,32 +25,61 @@ def test_traces_table_delegates(qtrace):
     curves_model = qtrace.curves_model
     table_view = qtrace.ui.traces_tbl
 
-    axis_col = curves_model.getColumnIndex("Y-Axis Name")
-    color_col = curves_model.getColumnIndex("Color")
-    style_col = curves_model.getColumnIndex("Style")
-    line_style_col = curves_model.getColumnIndex("Line Style")
-    line_width_col = curves_model.getColumnIndex("Line Width")
-    symbol_col = curves_model.getColumnIndex("Symbol")
-    symbol_size_col = curves_model.getColumnIndex("Symbol Size")
-    delete_col = curves_model.getColumnIndex("")
-
-    assert type(table_view.itemDelegateForColumn(axis_col)) is ComboBoxDelegate
-    assert type(table_view.itemDelegateForColumn(color_col)) is ColorButtonDelegate
-    assert type(table_view.itemDelegateForColumn(style_col)) is ComboBoxDelegate
-    assert type(table_view.itemDelegateForColumn(line_style_col)) is ComboBoxDelegate
-    assert type(table_view.itemDelegateForColumn(line_width_col)) is ComboBoxDelegate
-    assert type(table_view.itemDelegateForColumn(symbol_col)) is ComboBoxDelegate
-    assert type(table_view.itemDelegateForColumn(symbol_size_col)) is ComboBoxDelegate
-    assert type(table_view.itemDelegateForColumn(delete_col)) is DeleteRowDelegate
-
-
-def test_drag_drop(qtrace):
-    pass
-
-
-def test_context_menu(qtrace):
-    pass
+    delegates = []
+    for column in range(curves_model.columnCount()):
+        delegate = table_view.itemDelegateForColumn(column)
+        delegates.append(type(delegate) if delegate else None)
+    expected = [
+        None,
+        None,
+        None,
+        None,
+        ColorButtonDelegate,
+        ComboBoxDelegate,
+        ComboBoxDelegate,
+        ComboBoxDelegate,
+        ComboBoxDelegate,
+        ComboBoxDelegate,
+        ComboBoxDelegate,
+        None,
+        DeleteRowDelegate,
+    ]
+    assert delegates == expected
 
 
-def test_formula_dialog(qtrace):
-    pass
+@pytest.mark.parametrize(
+    ("test_data", "expected_calls"),
+    (("FOO:BAR:CHANNEL", 1), ("FOO:CHANNEL, BAR:CHANNEL", 2), ("FOO:CHANNEL BAR:CHANNEL", 2)),
+)
+def test_insert_pvs(qtrace, test_data, expected_calls):
+    """Test that insertPVs() calls curves_model.set_data the correct amount of
+    times. Splits on whitespace or commas.
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    test_data : str
+        Data that resembles what insertPVs() might recieve
+    expected_calls : int
+        The number of times curves_model.set_data() is expected to be called
+
+    Expectations
+    ------------
+    curves_model.set_data gets called the expected number of times.
+    """
+    qtrace.curves_model.set_data = mock.Mock()
+
+    qtrace.insertPVs(test_data)
+
+    assert qtrace.curves_model.set_data.call_count == expected_calls
+
+
+def test_formula_dialog(qtrace, get_test_file):
+    test_filename = get_test_file("test_file.trc")
+    test_data = loads(test_filename.read_text())
+
+    qtrace.curves_model.set_model_curves(test_data["curves"])
+
+    # TODO: Keep working on it
+    assert False

--- a/trace/tests/test_table_models/test_axis_model.py
+++ b/trace/tests/test_table_models/test_axis_model.py
@@ -1,5 +1,6 @@
 from json import loads
 
+import pytest
 from qtpy.QtCore import Qt
 
 
@@ -84,6 +85,7 @@ def test_remove_axis(qtrace):
     """
     axis_model = qtrace.axis_table_model
     axis_model.removeAtIndex(axis_model.index(0, 0))
+
     assert axis_model.rowCount() == 1
     assert axis_model.data(axis_model.index(0, 0)) == "Axis 1"
 
@@ -100,7 +102,8 @@ def test_remove_axis(qtrace):
 
 
 def test_set_model_axes(qtrace, get_test_file):
-    """
+    """Test that setting ArchiverAxisModel.set_model_axes() actually sets the
+    model with the expected y-axes
 
     Parameters
     ----------
@@ -111,14 +114,61 @@ def test_set_model_axes(qtrace, get_test_file):
 
     Expectations
     ------------
+    Calling ArchiverAxisModel.set_model_axes() results in the model containing
+    the set y-axis data
     """
     test_filename = get_test_file("test_file.trc")
     test_data = loads(test_filename.read_text())
 
-    qtrace.axis_table_model.set_model_axes(test_data["y-axes"])
+    axis_model = qtrace.axis_table_model
+    axis_model.set_model_axes(test_data["y-axes"])
 
-    assert False
+    plot_data = qtrace.main_plot.getYAxes()
+    for axis_test, axis_json in zip(test_data["y-axes"], plot_data):
+        axis_actual = loads(axis_json)
+        assert axis_test.items() <= axis_actual.items()
 
 
-def test_alter_axis_data(qtrace):
-    pass
+@pytest.mark.parametrize(
+    ["column", "data_test", "data_expected"],
+    [
+        (0, "FOO Axis", "FOO Axis"),
+        (1, "right", "Right"),
+        (2, "FOO Label", "FOO Label"),
+        (3, -15.0, -15.0),
+        (3, 20.0, 1.04),
+        (4, -15.0, -1.04),
+        (4, 20.0, 20.0),
+        (5, Qt.Checked, Qt.Checked),
+        (5, Qt.Unchecked, Qt.Unchecked),
+        (6, Qt.Checked, Qt.Checked),
+        (6, Qt.Unchecked, Qt.Unchecked),
+    ],
+)
+def test_alter_axis_data(qtrace, column, data_test, data_expected):
+    """Test that users can set data in the ArchiverAxisModel
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    column : int
+        The column to set the test data in
+    data_test : Any
+        The test data to set for a given column
+    data_expected : Any
+        The expected value to be stored in the model for the given index
+
+    Expectations
+    ------------
+    The given column and test data should result in the given expected data
+    """
+    axis_model = qtrace.axis_table_model
+
+    index = axis_model.index(0, column)
+    role = Qt.CheckStateRole if column in axis_model.checkable_col else Qt.EditRole
+
+    axis_model.setData(axis_model.index(0, column), data_test, role)
+    data_actual = index.data(role)
+
+    assert data_expected == data_actual

--- a/trace/tests/test_table_models/test_axis_model.py
+++ b/trace/tests/test_table_models/test_axis_model.py
@@ -1,3 +1,5 @@
+from json import loads
+
 from qtpy.QtCore import Qt
 
 
@@ -19,7 +21,17 @@ def test_axis_table_model_qtmodeltester(qtmodeltester, qtrace):
 
 
 def test_default_axis(qtrace):
-    """Check default values for axis as represented in the table model"""
+    """Check default values for axis as represented in the table model
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    The data in the initial row match expected data
+    """
     axis_model = qtrace.axis_table_model
 
     row_actual = []
@@ -35,15 +47,77 @@ def test_default_axis(qtrace):
 
 
 def test_append_axis(qtrace):
-    pass
+    """Test appending new axes to the axis model
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    Appending to the model adds an axis, either with the given name or an
+    incremented name
+    """
+    axis_model = qtrace.axis_table_model
+    axis_model.append()
+    axis_model.append("FOOBAR")
+
+    assert axis_model.rowCount() == 3
+    assert axis_model.data(axis_model.index(0, 0)) == "Axis 1"
+    assert axis_model.data(axis_model.index(1, 0)) == "Axis 2"
+    assert axis_model.data(axis_model.index(2, 0)) == "FOOBAR"
 
 
 def test_remove_axis(qtrace):
-    pass
+    """Test appending new axes to the axis model
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    Appending to the model adds an axis, either with the given name or an
+    incremented name
+    """
+    axis_model = qtrace.axis_table_model
+    axis_model.removeAtIndex(axis_model.index(0, 0))
+    assert axis_model.rowCount() == 1
+    assert axis_model.data(axis_model.index(0, 0)) == "Axis 1"
+
+    axis_model.append("FOO")
+    axis_model.append("BAR")
+    axis_model.append("FOOBAR")
+
+    axis_model.removeAtIndex(axis_model.index(1, 0))
+    axis_model.removeAxis("BAR")
+
+    assert axis_model.rowCount() == 2
+    assert axis_model.data(axis_model.index(0, 0)) == "Axis 1"
+    assert axis_model.data(axis_model.index(1, 0)) == "FOOBAR"
 
 
-def test_set_model_axes(qtrace):
-    pass
+def test_set_model_axes(qtrace, get_test_file):
+    """
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    get_test_file : fixture
+        A fixture used to get test files from the test_data directory
+
+    Expectations
+    ------------
+    """
+    test_filename = get_test_file("test_file.trc")
+    test_data = loads(test_filename.read_text())
+
+    qtrace.axis_table_model.set_model_axes(test_data["y-axes"])
+
+    assert False
 
 
 def test_alter_axis_data(qtrace):

--- a/trace/tests/test_table_models/test_axis_model.py
+++ b/trace/tests/test_table_models/test_axis_model.py
@@ -33,15 +33,15 @@ def test_default_axis(qtrace):
     ------------
     The data in the initial row match expected data
     """
-    axis_model = qtrace.axis_table_model
+    model = qtrace.axis_table_model
 
     row_actual = []
     row_expected = ["Axis 1", "Left", None, -1.04, 1.04, Qt.Checked, Qt.Unchecked, Qt.Unchecked, None]
 
-    for col in range(axis_model.columnCount()):
-        index = axis_model.index(0, col)
-        role = Qt.CheckStateRole if col in axis_model.checkable_col else Qt.DisplayRole
-        data = axis_model.data(index, role)
+    for col in range(model.columnCount()):
+        index = model.index(0, col)
+        role = Qt.CheckStateRole if col in model.checkable_col else Qt.DisplayRole
+        data = model.data(index, role)
         row_actual.append(data)
 
     assert row_actual == row_expected
@@ -60,14 +60,14 @@ def test_append_axis(qtrace):
     Appending to the model adds an axis, either with the given name or an
     incremented name
     """
-    axis_model = qtrace.axis_table_model
-    axis_model.append()
-    axis_model.append("FOOBAR")
+    model = qtrace.axis_table_model
+    model.append()
+    model.append("FOOBAR")
 
-    assert axis_model.rowCount() == 3
-    assert axis_model.data(axis_model.index(0, 0)) == "Axis 1"
-    assert axis_model.data(axis_model.index(1, 0)) == "Axis 2"
-    assert axis_model.data(axis_model.index(2, 0)) == "FOOBAR"
+    assert model.rowCount() == 3
+    assert model.data(model.index(0, 0)) == "Axis 1"
+    assert model.data(model.index(1, 0)) == "Axis 2"
+    assert model.data(model.index(2, 0)) == "FOOBAR"
 
 
 def test_remove_axis(qtrace):
@@ -83,22 +83,22 @@ def test_remove_axis(qtrace):
     Appending to the model adds an axis, either with the given name or an
     incremented name
     """
-    axis_model = qtrace.axis_table_model
-    axis_model.removeAtIndex(axis_model.index(0, 0))
+    model = qtrace.axis_table_model
+    model.removeAtIndex(model.index(0, 0))
 
-    assert axis_model.rowCount() == 1
-    assert axis_model.data(axis_model.index(0, 0)) == "Axis 1"
+    assert model.rowCount() == 1
+    assert model.data(model.index(0, 0)) == "Axis 1"
 
-    axis_model.append("FOO")
-    axis_model.append("BAR")
-    axis_model.append("FOOBAR")
+    model.append("FOO")
+    model.append("BAR")
+    model.append("FOOBAR")
 
-    axis_model.removeAtIndex(axis_model.index(1, 0))
-    axis_model.removeAxis("BAR")
+    model.removeAtIndex(model.index(1, 0))
+    model.removeAxis("BAR")
 
-    assert axis_model.rowCount() == 2
-    assert axis_model.data(axis_model.index(0, 0)) == "Axis 1"
-    assert axis_model.data(axis_model.index(1, 0)) == "FOOBAR"
+    assert model.rowCount() == 2
+    assert model.data(model.index(0, 0)) == "Axis 1"
+    assert model.data(model.index(1, 0)) == "FOOBAR"
 
 
 def test_set_model_axes(qtrace, get_test_file):
@@ -120,8 +120,8 @@ def test_set_model_axes(qtrace, get_test_file):
     test_filename = get_test_file("test_file.trc")
     test_data = loads(test_filename.read_text())
 
-    axis_model = qtrace.axis_table_model
-    axis_model.set_model_axes(test_data["y-axes"])
+    model = qtrace.axis_table_model
+    model.set_model_axes(test_data["y-axes"])
 
     plot_data = qtrace.main_plot.getYAxes()
     for axis_test, axis_json in zip(test_data["y-axes"], plot_data):
@@ -163,12 +163,12 @@ def test_alter_axis_data(qtrace, column, data_test, data_expected):
     ------------
     The given column and test data should result in the given expected data
     """
-    axis_model = qtrace.axis_table_model
+    model = qtrace.axis_table_model
 
-    index = axis_model.index(0, column)
-    role = Qt.CheckStateRole if column in axis_model.checkable_col else Qt.EditRole
+    index = model.index(0, column)
+    role = Qt.CheckStateRole if column in model.checkable_col else Qt.EditRole
 
-    axis_model.setData(axis_model.index(0, column), data_test, role)
+    model.setData(index, data_test, role)
     data_actual = index.data(role)
 
     assert data_expected == data_actual

--- a/trace/tests/test_table_models/test_axis_model.py
+++ b/trace/tests/test_table_models/test_axis_model.py
@@ -1,9 +1,24 @@
 from qtpy.QtCore import Qt
 
-from main import TraceDisplay
+
+def test_axis_table_model_qtmodeltester(qtmodeltester, qtrace):
+    """Check the validity of the ArchiverAxisModel with pytest-qt
+
+    Parameters
+    ----------
+    qtmodeltester : fixture
+        pytest-qt fixture used for testing the validity of AbstractItemModels
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    qtmodeltester finds no issues with the model
+    """
+    qtmodeltester.check(qtrace.axis_table_model, force_py=True)
 
 
-def test_default_axis(qtrace: TraceDisplay):
+def test_default_axis(qtrace):
     """Check default values for axis as represented in the table model"""
     axis_model = qtrace.axis_table_model
 
@@ -19,17 +34,17 @@ def test_default_axis(qtrace: TraceDisplay):
     assert row_actual == row_expected
 
 
-def test_append_axis(qtrace: TraceDisplay):
+def test_append_axis(qtrace):
     pass
 
 
-def test_remove_axis(qtrace: TraceDisplay):
+def test_remove_axis(qtrace):
     pass
 
 
-def test_set_model_axes(qtrace: TraceDisplay):
+def test_set_model_axes(qtrace):
     pass
 
 
-def test_alter_axis_data(qtrace: TraceDisplay):
+def test_alter_axis_data(qtrace):
     pass

--- a/trace/tests/test_table_models/test_curve_model.py
+++ b/trace/tests/test_table_models/test_curve_model.py
@@ -1,4 +1,12 @@
+import faulthandler
+from json import loads
+
+import pytest
 from qtpy.QtCore import Qt
+
+from pydm.widgets.archiver_time_plot import FormulaCurveItem, ArchivePlotCurveItem
+
+faulthandler.enable()
 
 
 def test_curves_model_qtmodeltester(qtmodeltester, qtrace):
@@ -19,72 +27,255 @@ def test_curves_model_qtmodeltester(qtmodeltester, qtrace):
 
 
 def test_default_curve(qtrace):
-    """Check default values for curve as represented in the table model"""
-    curves_model = qtrace.curves_model
+    """Check default values for curve as represented in the table model
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    The data in the initial row match expected data
+    """
+    model = qtrace.curves_model
 
     row_actual = []
     row_expected = ["", Qt.Checked, Qt.Checked, "", "#008cf9", "Axis 1",
                     "Direct", "Solid", "1px", "None", "10px", Qt.Checked, None]  # fmt: skip
 
-    for col in range(curves_model.columnCount()):
-        index = curves_model.index(0, col)
-        role = Qt.CheckStateRole if col in curves_model.checkable_cols else Qt.DisplayRole
-        data = curves_model.data(index, role)
+    for col in range(model.columnCount()):
+        index = model.index(0, col)
+        role = Qt.CheckStateRole if col in model.checkable_cols else Qt.DisplayRole
+        data = model.data(index, role)
         row_actual.append(data)
 
     assert row_actual == row_expected
 
 
 def test_contains(qtrace):
-    pass
+    model = qtrace.curves_model
+    index = model.index(0, 0)
+    model.setData(index, "FOO:CHANNEL", Qt.EditRole)
+
+    assert "FOO:CHANNEL" in model
+    assert None in model
+    assert "BAR:CHANNEL" not in model
 
 
 def test_append_curve(qtrace):
-    pass
+    model = qtrace.curves_model
+    assert model.rowCount() == 1
+
+    model.append()
+    assert model.rowCount() == 2
+
+    model.append()
+    assert model.rowCount() == 3
 
 
 def test_remove_curve(qtrace):
-    pass
+    model = qtrace.curves_model
+    assert model.rowCount() == 1
+
+    model.append("FOO:CHANNEL")
+    assert model.rowCount() == 2 and "FOO:CHANNEL" in model
+
+    index = model.index(0, 0)
+    model.removeAtIndex(index)
+    assert model.rowCount() == 1 and "FOO:CHANNEL" in model
+
+    index = model.index(0, 0)
+    model.removeAtIndex(index)
+    assert model.rowCount() == 1 and "FOO:CHANNEL" in model
 
 
-def test_set_model_curves(qtrace):
-    pass
+def test_set_model_curves(qtrace, get_test_file):
+    """Test that setting ArchiverCurveModel.set_model_curves() actually sets the
+    model with the expected curves
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    get_test_file : fixture
+        A fixture used to get test files from the test_data directory
+
+    Expectations
+    ------------
+    Calling ArchiverCurveModel.set_model_curves() results in the model containing
+    the set curves data
+    """
+    test_filename = get_test_file("test_file.trc")
+    test_data = loads(test_filename.read_text())
+
+    qtrace.curves_model.set_model_curves(test_data["curves"])
+
+    assert "KLYS:LI22:31:KVAC" in qtrace.curves_model
+    assert None in qtrace.curves_model
+    assert "FOO:BAR:CHANNEL" not in qtrace.curves_model
 
 
-def test_alter_curve_data(qtrace):
-    pass
+@pytest.mark.parametrize(
+    ["column", "data_test", "data_expected"],
+    [
+        (0, "FOO:Curve", "FOO:Curve"),
+        (1, Qt.Unchecked, Qt.Unchecked),
+        (2, Qt.Unchecked, Qt.Unchecked),
+        (3, "FOO Label", "FOO Label"),
+        (4, "lime", "lime"),
+        (5, "Axis 2", "Axis 2"),
+        (6, "left", "Step"),
+        (7, 3, "Dot"),
+        (8, 2, "2px"),
+        (9, "star", "Star"),
+        (10, 20, "20px"),
+        (11, Qt.Unchecked, Qt.Unchecked),
+    ],
+)
+def test_alter_curve_data(qtrace, column, data_test, data_expected):
+    """Test that users can set data in the ArchiverAxisModel
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    column : int
+        The column to set the test data in
+    data_test : Any
+        The test data to set for a given column
+    data_expected : Any
+        The expected value to be stored in the model for the given index
+
+    Expectations
+    ------------
+    The given column and test data should result in the given expected data
+    """
+    model = qtrace.curves_model
+    model.append()
+
+    index = model.index(0, column)
+    role = Qt.CheckStateRole if column in model.checkable_cols else Qt.EditRole
+
+    model.setData(index, data_test, role)
+    data_actual = index.data(role)
+
+    assert data_actual == data_expected
 
 
 def test_convert_curve_to_formula(qtrace):
-    pass
+    model = qtrace.curves_model
+
+    index = model.index(0, 0)
+    model.setData(index, "f://5+1", Qt.EditRole)
+    assert isinstance(model.curve_at_index(0), FormulaCurveItem)
+
+    index = model.index(1, 0)
+    model.setData(index, "f://{A} * 2", Qt.EditRole)
+    assert isinstance(model.curve_at_index(1), FormulaCurveItem)
 
 
-def test_convert_formula_to_curve(qtrace):
-    pass
+def test_convert_formula_to_curve(qtrace, mock_logger):
+    model = qtrace.curves_model
+
+    index = model.index(0, 0)
+    model.setData(index, "f://{B}+1", Qt.EditRole)
+    mock_logger.error.assert_called_once_with("B is an invalid variable name")
+
+    model.setData(index, "f://5+1", Qt.EditRole)
+    assert isinstance(model.curve_at_index(0), FormulaCurveItem)
+
+    model.setData(index, "FOO:CHANNEL", Qt.EditRole)
+    assert isinstance(model.curve_at_index(0), ArchivePlotCurveItem)
 
 
-def test_invalid_formula(qtrace):
-    pass
+def test_recursive_formula(qtrace, mock_logger):
+    model = qtrace.curves_model
+
+    index = model.index(0, 0)
+    model.setData(index, "f://{A}+1", Qt.EditRole)
+    mock_logger.error.assert_called_once_with("A is recursive")
+
+    mock_logger.error.reset_mock()
+    model.setData(index, "f://5+1", Qt.EditRole)
+
+    model.setData(model.index(1, 0), "f://{A}+1", Qt.EditRole)
+    model.setData(model.index(0, 0), "f://{B}+1", Qt.EditRole)
+    mock_logger.error.assert_called_once_with("There was a recursive dependency somewhere")
 
 
-def test_recursive_formula(qtrace):
-    pass
+@pytest.mark.parametrize(
+    ["data_test", "data_expected"],
+    [(None, "B"), ("L", "M"), ("Z", "AA"), ("LM", "LN"), ("AZ", "BA"), ("ZZZZ", "AAAAA")],
+)
+def test_next_header(qtrace, data_test, data_expected):
+    model = qtrace.curves_model
+    if data_test:
+        model._row_names.append(data_test)
+
+    data_actual = model.next_header()
+    assert data_actual == data_expected
 
 
-def test_next_header(qtrace):
-    pass
+@pytest.mark.parametrize("enabled", [True, False])
+def test_live_connection_status(qtrace, enabled):
+    model = qtrace.curves_model
+    model.setData(model.index(0, 0), "FOO:CHANNEL", Qt.EditRole)
+
+    curve = model.curve_at_index(0)
+    curve.live_channel_connection.emit(enabled)
+    live_flags = model.flags(model.index(0, 1))
+
+    assert bool(live_flags & Qt.ItemIsEnabled) == enabled
 
 
-def test_live_connection_status(qtrace):
-    pass
+@pytest.mark.parametrize("enabled", [True, False])
+def test_archive_connection_status(qtrace, enabled):
+    """Test that the model reflects a curve's archive connection status
 
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    enabled : bool
+        Enable/disable the archive connection status; used as test data and
+        expected value
 
-def test_archive_connection_status(qtrace):
-    pass
+    Expectations
+    ------------
+    When the curve's archive connection status is disconnected, the table will
+    disable the checkbox for fetching archive data and make its background red
+    """
+    model = qtrace.curves_model
+    model.setData(model.index(0, 0), "FOO:CHANNEL", Qt.EditRole)
+
+    curve = model.curve_at_index(0)
+    curve.archive_channel_connection.emit(enabled)
+    archive_flags = model.flags(model.index(0, 2))
+
+    assert bool(archive_flags & Qt.ItemIsEnabled) == enabled
 
 
 def test_set_axis_from_unit(qtrace):
     """Check that when a curve's units change, the curve is moved to an axis
     that reflects the new units.
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    The curve's unit changing should create a new axis. The curve should be
+    attached to the new axis.
     """
-    pass
+    model = qtrace.curves_model
+    curve = model.curve_at_index(0)
+    model.setData(model.index(0, 0), "FOO:CHANNEL", Qt.EditRole)
+
+    assert curve.y_axis_name == "Axis 1"
+
+    curve.unitSignal.emit("foo unit")
+
+    assert curve.y_axis_name == "foo unit"

--- a/trace/tests/test_table_models/test_curve_model.py
+++ b/trace/tests/test_table_models/test_curve_model.py
@@ -54,6 +54,18 @@ def test_default_curve(qtrace):
 
 
 def test_contains(qtrace):
+    """Test that __contains__ works and that the 'in' keyword works with the model
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    The 'in' keyword should correctly tell us if a curve with the requested name
+    is a part of the model
+    """
     model = qtrace.curves_model
     index = model.index(0, 0)
     model.setData(index, "FOO:CHANNEL", Qt.EditRole)
@@ -64,6 +76,17 @@ def test_contains(qtrace):
 
 
 def test_append_curve(qtrace):
+    """Test that append actually adds a curve to the model
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    The model should have 1 more curve after append is called
+    """
     model = qtrace.curves_model
     assert model.rowCount() == 1
 
@@ -75,6 +98,17 @@ def test_append_curve(qtrace):
 
 
 def test_remove_curve(qtrace):
+    """Test that removeAtIndex actually removes the curve from the model
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    The removed object should no longer be in the model
+    """
     model = qtrace.curves_model
     assert model.rowCount() == 1
 
@@ -164,6 +198,17 @@ def test_alter_curve_data(qtrace, column, data_test, data_expected):
 
 
 def test_convert_curve_to_formula(qtrace):
+    """Test that conversion from an ArchiverPlotCurveItem to a FormulaCurveItem
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    The selected curve object should be an instance of the expected class
+    """
     model = qtrace.curves_model
 
     index = model.index(0, 0)
@@ -176,6 +221,19 @@ def test_convert_curve_to_formula(qtrace):
 
 
 def test_convert_formula_to_curve(qtrace, mock_logger):
+    """Test that conversion from a FormulaCurveItem to an ArchiverPlotCurveItem
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    mock_logger : fixture
+        A fixture used for mocking the logger's warning and error methods
+
+    Expectations
+    ------------
+    The selected curve object should be an instance of the expected class
+    """
     model = qtrace.curves_model
 
     index = model.index(0, 0)
@@ -190,6 +248,19 @@ def test_convert_formula_to_curve(qtrace, mock_logger):
 
 
 def test_recursive_formula(qtrace, mock_logger):
+    """Test the recursive formula checker
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    mock_logger : fixture
+        A fixture used for mocking the logger's warning and error methods
+
+    Expectations
+    ------------
+    Users should be prevented from entering recursive formulas and an error should be printed to stdout
+    """
     model = qtrace.curves_model
 
     index = model.index(0, 0)
@@ -209,6 +280,21 @@ def test_recursive_formula(qtrace, mock_logger):
     [(None, "B"), ("L", "M"), ("Z", "AA"), ("LM", "LN"), ("AZ", "BA"), ("ZZZZ", "AAAAA")],
 )
 def test_next_header(qtrace, data_test, data_expected):
+    """Test the row header generation works as expected
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    data_test : str
+        The "last header" in the table to test against
+    data_expected : str
+        The expected header to be returned based on the "last header"
+
+    Expectations
+    ------------
+    Row headers should be generated based on the previous header
+    """
     model = qtrace.curves_model
     if data_test:
         model._row_names.append(data_test)
@@ -219,6 +305,21 @@ def test_next_header(qtrace, data_test, data_expected):
 
 @pytest.mark.parametrize("enabled", [True, False])
 def test_live_connection_status(qtrace, enabled):
+    """Test that the model reflects a curve's live connection status
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    enabled : bool
+        Enable/disable the live connection status; used as test data and
+        expected value
+
+    Expectations
+    ------------
+    When the curve's live connection status is disconnected, the table will
+    disable the checkbox for fetching live data and make its background red
+    """
     model = qtrace.curves_model
     model.setData(model.index(0, 0), "FOO:CHANNEL", Qt.EditRole)
 

--- a/trace/tests/test_table_models/test_curve_model.py
+++ b/trace/tests/test_table_models/test_curve_model.py
@@ -1,14 +1,29 @@
-from qtpy.QtCore import Qt, QVariant
-
-from main import TraceDisplay
+from qtpy.QtCore import Qt
 
 
-def test_default_curve(qtrace: TraceDisplay):
+def test_curves_model_qtmodeltester(qtmodeltester, qtrace):
+    """Check the validity of the ArchiverCurveModel with pytest-qt
+
+    Parameters
+    ----------
+    qtmodeltester : fixture
+        pytest-qt fixture used for testing the validity of AbstractItemModels
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    qtmodeltester finds no issues with the model
+    """
+    qtmodeltester.check(qtrace.curves_model, force_py=True)
+
+
+def test_default_curve(qtrace):
     """Check default values for curve as represented in the table model"""
     curves_model = qtrace.curves_model
 
     row_actual = []
-    row_expected = [QVariant(), Qt.Checked, Qt.Checked, "", "#008cf9", "Axis 1",
+    row_expected = ["", Qt.Checked, Qt.Checked, "", "#008cf9", "Axis 1",
                     "Direct", "Solid", "1px", "None", "10px", Qt.Checked, None]  # fmt: skip
 
     for col in range(curves_model.columnCount()):
@@ -20,55 +35,55 @@ def test_default_curve(qtrace: TraceDisplay):
     assert row_actual == row_expected
 
 
-def test_contains(qtrace: TraceDisplay):
+def test_contains(qtrace):
     pass
 
 
-def test_append_curve(qtrace: TraceDisplay):
+def test_append_curve(qtrace):
     pass
 
 
-def test_remove_curve(qtrace: TraceDisplay):
+def test_remove_curve(qtrace):
     pass
 
 
-def test_set_model_curves(qtrace: TraceDisplay):
+def test_set_model_curves(qtrace):
     pass
 
 
-def test_alter_curve_data(qtrace: TraceDisplay):
+def test_alter_curve_data(qtrace):
     pass
 
 
-def test_convert_curve_to_formula(qtrace: TraceDisplay):
+def test_convert_curve_to_formula(qtrace):
     pass
 
 
-def test_convert_formula_to_curve(qtrace: TraceDisplay):
+def test_convert_formula_to_curve(qtrace):
     pass
 
 
-def test_invalid_formula(qtrace: TraceDisplay):
+def test_invalid_formula(qtrace):
     pass
 
 
-def test_recursive_formula(qtrace: TraceDisplay):
+def test_recursive_formula(qtrace):
     pass
 
 
-def test_next_header(qtrace: TraceDisplay):
+def test_next_header(qtrace):
     pass
 
 
-def test_live_connection_status(qtrace: TraceDisplay):
+def test_live_connection_status(qtrace):
     pass
 
 
-def test_archive_connection_status(qtrace: TraceDisplay):
+def test_archive_connection_status(qtrace):
     pass
 
 
-def test_set_axis_from_unit(qtrace: TraceDisplay):
+def test_set_axis_from_unit(qtrace):
     """Check that when a curve's units change, the curve is moved to an axis
     that reflects the new units.
     """

--- a/trace/tests/test_widgets/test_table_widgets.py
+++ b/trace/tests/test_widgets/test_table_widgets.py
@@ -15,7 +15,7 @@ TEST_PALETTE = [
 ]
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def color_btn(qapp):
     """Fixture for an instance of the ColorButton. Sets the button's default color.
 

--- a/trace/trace_file_convert.py
+++ b/trace/trace_file_convert.py
@@ -623,7 +623,8 @@ class PathAction(Action):
 if __name__ == "__main__":
     parser = ArgumentParser(
         prog="Trace File Converter",
-        description="Convert files used by the Java Archive" " Viewer to a file format that can be used with Trace.",
+        description="Convert files used by the Java Archive Viewer or StripTool"
+        + " to a file format that can be used with Trace.",
     )
     parser.add_argument(
         "input_file", action=PathAction, type=str, nargs="*", help="Path to the file(s) to be converted"

--- a/trace/widgets/archive_search.py
+++ b/trace/widgets/archive_search.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import Any, List
 
 from qtpy.QtGui import QDrag, QKeyEvent
 from qtpy.QtCore import (
@@ -7,7 +7,6 @@ from qtpy.QtCore import (
     QUrl,
     Signal,
     QObject,
-    QVariant,
     QMimeData,
     QModelIndex,
     QAbstractTableModel,
@@ -55,17 +54,17 @@ class ArchiveResultsTableModel(QAbstractTableModel):
             return 0
         return len(self.column_names)
 
-    def data(self, index: QModelIndex, role: int) -> QVariant:
+    def data(self, index: QModelIndex, role: int) -> Any:
         """Return the data for the associated role. Currently only supporting DisplayRole."""
         if not index.isValid():
-            return QVariant()
+            return None
 
         if role != Qt.DisplayRole:
-            return QVariant()
+            return None
 
         return self.results_list[index.row()]
 
-    def headerData(self, section, orientation, role=Qt.DisplayRole) -> QVariant:
+    def headerData(self, section, orientation, role=Qt.DisplayRole) -> Any:
         """Return data associated with the header"""
         if role != Qt.DisplayRole:
             return super().headerData(section, orientation, role)


### PR DESCRIPTION
Adding a lot of tests for:
- Axis table model
- Curves table model
- Axis tab mixin
- Curves tab mixin
- ColorButton

Made a few minor fixes to models as well:
- Removed all references to QVariant as they are incorrectly used
- In ArchiverAxisModel.set_model_axes
  - Removed an extra axis that was always getting added at the end, but it shouldn't have been there
- In some instances where an exception is being passed straight into the logger, I convert the exception to a string for easier testing
- Fixed ArchiverCurveModel.flags to correctly return Qt.NoItemFlags if the given index is invalid