### PR TITLE
FIX: Add 1d Button to timespan_btns Button Group

### DIFF
--- a/trace/main.ui
+++ b/trace/main.ui
@@ -92,6 +92,9 @@
        <property name="checkable">
         <bool>true</bool>
        </property>
+       <attribute name="buttonGroup">
+        <string notr="true">timespan_btns</string>
+       </attribute>
       </widget>
      </item>
      <item>
@@ -324,8 +327,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>1146</width>
-             <height>416</height>
+             <width>230</width>
+             <height>310</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_3">


### PR DESCRIPTION
Fixing a mistake that was made when creating the quick timespan button for 1 day (labeled '1d'). The button was mistakenly left out of the `timespan_btns` button group, resulting in:
- the toggling not being exclusive to the other timespan buttons
- the button having no functionality when clicked/toggled

The solution was simply to add it in designer.