### PR TITLE
TST/FIX: ArchiveSearchWidget Tests

### DIFF
--- a/trace/config.json
+++ b/trace/config.json
@@ -1,9 +1,6 @@
 {
     "save_file_dir": "$PHYSICS_DATA/Trace/",
     "datetime_pv": "SIOC:SYS0:AL00:TOD",
-    "archivers": {
-        "LCLS": "http://lcls-archapp.slac.stanford.edu"
-    },
     "colors-java": [
         "#FF0000", "#0000FF", "#00FF00",
         "#FF00FF", "#000000", "#660099",

--- a/trace/config.py
+++ b/trace/config.py
@@ -19,8 +19,4 @@ if not save_file_dir.is_dir():
     save_file_dir = Path.home()
     logger.warning(f"Setting save_file_dir to home: {save_file_dir}")
 
-archiver_urls = loaded_json["archivers"]
-if not archiver_urls:
-    archiver_urls = [os.getenv("PYDM_ARCHIVER_URL")]
-
 color_palette = [QColor(hex_code) for hex_code in loaded_json["colors"]]

--- a/trace/tests/test_widgets/test_archive_search.py
+++ b/trace/tests/test_widgets/test_archive_search.py
@@ -1,9 +1,15 @@
+from os import getenv
+from unittest.mock import MagicMock, patch
+
 import pytest
+from qtpy.QtGui import QDrag
+from qtpy.QtCore import QUrl, QMimeData, QByteArray, QModelIndex
+from qtpy.QtNetwork import QNetworkReply, QNetworkRequest
 
 from widgets.archive_search import ArchiveSearchWidget
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def search_wid(qapp):
     """Fixture for an instance of the ArchiveSearchWidget.
 
@@ -14,13 +20,200 @@ def search_wid(qapp):
     yield ArchiveSearchWidget()
 
 
-def test_archive_search(search_wid):
-    pass
+def create_dummy_reply(data: bytes = b"", error_code=QNetworkReply.NoError):
+    """Helper function to create a mock QNetworkReply with specified data and error code.
+
+    Parameters
+    ----------
+    data : bytes
+        Data for the dummy QNetworkReply to return
+    error_code : QNetworkReply.NetworkError
+        Error code for the dummy QNetworkReply to return, default is QNetworkReply.NoError
+    """
+    reply = MagicMock(spec=QNetworkReply)
+    reply.error.return_value = error_code
+    reply.readAll.return_value = QByteArray(data)
+    return reply
 
 
-def test_drag_action(search_wid):
-    pass
+def test_archive_results_table_qtmodeltester(qtmodeltester, search_wid):
+    """Check the validity of the ArchiveResultsTableModel with pytest-qt
+
+    Parameters
+    ----------
+    qtmodeltester : fixture
+        pytest-qt fixture used for testing the validity of AbstractItemModels
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+    Expectations
+    ------------
+    qtmodeltester finds no issues with the model
+    """
+    qtmodeltester.check(search_wid.results_table_model, force_py=True)
 
 
-def test_insert_pvs(search_wid):
-    pass
+@pytest.mark.parametrize(
+    ("data_test", "data_expected"),
+    (
+        ("FOO:BAR:CHANNEL", "FOO:BAR:CHANNEL"),
+        ("FOO:?:CHANNEL", "FOO:.:CHANNEL"),
+        ("FOO:*:CHANNEL", "FOO:.*:CHANNEL"),
+        ("FOO:%:CHANNEL", "FOO:.*:CHANNEL"),
+    ),
+)
+@patch("qtpy.QtNetwork.QNetworkAccessManager.get")
+def test_archive_search(mock_get, search_wid, data_test, data_expected):
+    """Test that the ArchiveSearchWidget properly formats requests to the archiver appliance.
+
+    Parameters
+    ----------
+    mock_get : mock.patch
+        Mock qtpy.QtNetwork.QNetworkAccessManager.get to capture calls sent to the archiver
+    search_wid : fixture
+        Instance of ArchiveSearchWidget for testing
+    data_test : str
+        The text to search for
+    data_expected : str
+        The expected text sent in the archiver request
+
+    Expectations
+    ------------
+    Wild card characters should be replaced and requests to the archiver should be properly formatted.
+    """
+    search_wid.search_box.setText(data_test)
+    search_wid.search_button.click()
+
+    archiver_url = getenv("PYDM_ARCHIVER_URL")
+    url_string = f"{archiver_url}/retrieval/bpl/searchForPVsRegex?regex=.*{data_expected}.*"
+    mock_get.assert_called_once_with(QNetworkRequest(QUrl(url_string)))
+
+
+def test_populate_results_list_success(search_wid):
+    """Test case for populate_results_list method
+
+    Parameters
+    ----------
+    search_wid : fixture
+        Instance of ArchiveSearchWidget for testing
+
+    Expectations
+    ------------
+    A QNetworkReply sent to populate_results_list should get parsed and PVs should be added to results_table_model
+    """
+    # Create a mock QNetworkReply with sample data
+    sample_data = b"PV1 PV2 PV3"
+    reply = create_dummy_reply(data=sample_data)
+
+    # Assume self.results_table_model and self.loading_label are set up
+    with patch.object(search_wid, "results_table_model") as mock_table_model, \
+         patch.object(search_wid, "loading_label") as mock_loading_label:  # fmt: skip
+        # Run the populate_results_list function
+        search_wid.populate_results_list(reply)
+
+        # Assertions to verify behavior
+        mock_loading_label.hide.assert_called_once()
+        mock_table_model.clear.assert_called_once()
+        mock_table_model.replace_rows.assert_called_once_with(["PV1", "PV2", "PV3"])
+        reply.deleteLater.assert_called_once()
+
+
+def test_populate_results_list_error(search_wid):
+    """Test case for populate_results_list method when the given QNetworkReply has an error
+
+    Parameters
+    ----------
+    search_wid : fixture
+        Instance of ArchiveSearchWidget for testing
+
+    Expectations
+    ------------
+    The data in the QNetworkReply w/ error should be ignored and the logger should give a message
+    """
+    # Create a mock QNetworkReply that simulates an error
+    error_reply = create_dummy_reply(error_code=QNetworkReply.UnknownServerError)
+
+    # Assume self.results_table_model and self.loading_label are set up
+    with patch.object(search_wid, "results_table_model") as mock_table_model, \
+         patch.object(search_wid, "loading_label") as mock_loading_label, \
+         patch("widgets.archive_search.logger.error") as mock_logger_error:  # fmt: skip
+        # Run the populate_results_list function
+        search_wid.populate_results_list(error_reply)
+
+        # Assertions to verify behavior
+        mock_loading_label.hide.assert_called_once()
+        mock_table_model.clear.assert_not_called()  # Should not clear table on error
+        mock_logger_error.assert_called_once_with(f"Could not retrieve archiver results due to: {error_reply.error()}")
+        error_reply.deleteLater.assert_called_once()
+
+
+def test_start_drag_action(search_wid):
+    """Test ArchiveSearchWidget.startDragAction, used for dragging text to the main trace application
+
+    Parameters
+    ----------
+    search_wid : fixture
+        Instance of ArchiveSearchWidget for testing
+
+    Expectations
+    ------------
+    The QDrag action is initialized properly and contains the right mime data
+    """
+    # Patch the QDrag and QMimeData classes to monitor their usage
+    with patch.object(search_wid, "selectedPVs", return_value="PV1 PV2 PV3"), \
+         patch.object(QMimeData, "setText") as mock_setText, \
+         patch.object(QDrag, "setMimeData") as mock_setMimeData, \
+         patch.object(QDrag, "exec_", return_value=None) as mock_exec:  # fmt: skip
+        # Run the startDragAction method
+        search_wid.startDragAction(supported_actions=None)
+
+        # Assertions to verify behavior
+        mock_setText.assert_called_once_with("PV1 PV2 PV3")
+        mock_setMimeData.assert_called_once()
+        mock_exec.assert_called_once()
+
+
+def test_insert_button(search_wid):
+    """Test ArchiveSearchWidget.insert_button widget
+
+    Parameters
+    ----------
+    search_wid : fixture
+        Instance of ArchiveSearchWidget for testing
+
+    Expectations
+    ------------
+    Clicking the button results in the signal ArchiveSearchWidget.append_PVs_requested
+    being emitted for all listeners. The signal should include the return value
+    of ArchiveSearchWidget.selectedPVs
+    """
+    with patch.object(search_wid, "append_PVs_requested") as mock_append_signal, \
+         patch.object(search_wid, "selectedPVs", return_value="PV1 PV2 PV3"):  # fmt: skip
+        # Prompt the insertion by mimicing a user clicking the insert_button
+        search_wid.insert_button.click()
+
+        # Assertions to verify behavior
+        mock_append_signal.emit.assert_called_once_with("PV1 PV2 PV3")
+
+
+def test_result_view_double_click(search_wid):
+    """Test double-clicking ArchiveSearchWidget.results_view
+
+    Parameters
+    ----------
+    search_wid : fixture
+        Instance of ArchiveSearchWidget for testing
+
+    Expectations
+    ------------
+    Double-clicking the table view results in the signal ArchiveSearchWidget.append_PVs_requested
+    being emitted for all listeners. The signal should include the return value
+    of ArchiveSearchWidget.selectedPVs
+    """
+    with patch.object(search_wid, "append_PVs_requested") as mock_append_signal, \
+         patch.object(search_wid, "selectedPVs", return_value="PV1 PV2 PV3"):  # fmt: skip
+        # Prompt the insertion by mimicing a user double-clicking the table
+        search_wid.results_view.doubleClicked.emit(QModelIndex())
+
+        # Assertions to verify behavior
+        mock_append_signal.emit.assert_called_once_with("PV1 PV2 PV3")

--- a/trace/widgets/archive_search.py
+++ b/trace/widgets/archive_search.py
@@ -215,11 +215,9 @@ class ArchiveSearchWidget(QWidget):
         """Send the search request to the archiver appliance based on the search string typed into the text box"""
         search_text = self.search_box.text()
         search_text = search_text.replace("?", ".")
-        search_text = search_text.replace("*", ".")
-        search_text = search_text.replace("%", ".")
-        url_string = (
-            f"http://{self.archive_url_textedit.text()}/" f"retrieval/bpl/searchForPVsRegex?regex=.*{search_text}.*"
-        )
+        search_text = search_text.replace("*", ".*")
+        search_text = search_text.replace("%", ".*")
+        url_string = f"{self.archive_url_textedit.text()}/retrieval/bpl/searchForPVsRegex?regex=.*{search_text}.*"
         request = QNetworkRequest(QUrl(url_string))
         self.network_manager.get(request)
         self.loading_label.show()

--- a/trace/widgets/archive_search.py
+++ b/trace/widgets/archive_search.py
@@ -24,7 +24,14 @@ from qtpy.QtWidgets import (
     QAbstractItemView,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("")
+if not logger.hasHandlers():
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("[%(asctime)s] [%(levelname)-8s] - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel("INFO")
+    handler.setLevel("INFO")
 
 
 class ArchiveResultsTableModel(QAbstractTableModel):

--- a/trace/widgets/archive_search.py
+++ b/trace/widgets/archive_search.py
@@ -1,4 +1,5 @@
 import logging
+from os import getenv
 from typing import Any, List
 
 from qtpy.QtGui import QDrag, QKeyEvent
@@ -134,7 +135,7 @@ class ArchiveSearchWidget(QWidget):
         self.layout = QVBoxLayout()
 
         self.archive_title_label = QLabel("Archive URL:")
-        self.archive_url_textedit = QLineEdit("lcls-archapp.slac.stanford.edu")
+        self.archive_url_textedit = QLineEdit(getenv("PYDM_ARCHIVER_URL"))
         self.archive_url_textedit.setFixedWidth(250)
         self.archive_url_textedit.setFixedHeight(25)
 

--- a/trace/widgets/archive_search.py
+++ b/trace/widgets/archive_search.py
@@ -42,15 +42,15 @@ class ArchiveResultsTableModel(QAbstractTableModel):
         self.results_list = []
         self.column_names = ("PV",)
 
-    def rowCount(self, parent: QObject) -> int:
+    def rowCount(self, index: QModelIndex = QModelIndex()) -> int:
         """Return the row count of the table"""
-        if parent is not None and parent.isValid():
+        if index is not None and index.isValid():
             return 0
         return len(self.results_list)
 
-    def columnCount(self, parent: QObject) -> int:
+    def columnCount(self, index: QModelIndex = QModelIndex()) -> int:
         """Return the column count of the table"""
-        if parent is not None and parent.isValid():
+        if index is not None and index.isValid():
             return 0
         return len(self.column_names)
 


### PR DESCRIPTION
Adding tests for `ArchiveSearchWidget` and `ArchiveResultsTableModel`.

Fixing issues that came up during testing:
- In `config.py` & `config.json`:
  - Remove `archiver_urls` because I realized they aren't being used anywhere in the project and could cause confusion
- In `archive_search.py`:
  - Change the method of getting the `logger` to prevent getting a duplicate
  - Fix `ArchiveResultsTableModel.rowCount` implementation because it requires an argument when it should default to an empty `QModelIndex`
  - Populate `ArchiveSearchWidget.archive_url_textedit` with `$PYDM_ARCHIVER_URL` instead of hardcoding the URL
  - In `ArchiveSearchWidget.request_archiver_info`, make some wildcards work for 1+ characters instead of just 1 character