### PR TITLE
TST: Tests For main.py

### DIFF
--- a/trace/main.py
+++ b/trace/main.py
@@ -1,10 +1,10 @@
 import os
 import argparse
+import subprocess
 from socket import gethostname
 from typing import Dict, List, Tuple, Union
 from getpass import getuser
 from logging import Handler, LogRecord
-from subprocess import run
 
 from qtpy.sip import isdeleted
 from qtpy.QtCore import Qt, Slot
@@ -207,7 +207,9 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
     def git_version():
         """Get the current git tag for the project"""
         project_directory = __file__.rsplit("/", 1)[0]
-        git_cmd = run(f"cd {project_directory} && git describe --tags", text=True, shell=True, capture_output=True)
+        git_cmd = subprocess.run(
+            f"cd {project_directory} && git describe --tags", text=True, shell=True, capture_output=True
+        )
         return git_cmd.stdout.strip()
 
     @Slot()

--- a/trace/tests/test_table_models/test_axis_model.py
+++ b/trace/tests/test_table_models/test_axis_model.py
@@ -129,6 +129,31 @@ def test_set_model_axes(qtrace, get_test_file):
         assert axis_test.items() <= axis_actual.items()
 
 
+def test_set_model_axes_empty(qtrace, get_test_file):
+    """Test that ArchiverAxisModel.set_model_axes() called with no arguments clears
+    the model
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    get_test_file : fixture
+        A fixture used to get test files from the test_data directory
+
+    Expectations
+    ------------
+    The ArchiverAxisModel will have no axes
+    """
+    test_filename = get_test_file("test_file.trc")
+    test_data = loads(test_filename.read_text())
+
+    model = qtrace.axis_table_model
+    model.set_model_axes(test_data["y-axes"])
+    model.set_model_axes()
+
+    assert model.rowCount() == 0
+
+
 @pytest.mark.parametrize(
     ["column", "data_test", "data_expected"],
     [

--- a/trace/tests/test_table_models/test_curve_model.py
+++ b/trace/tests/test_table_models/test_curve_model.py
@@ -150,6 +150,30 @@ def test_set_model_curves(qtrace, get_test_file):
     assert "FOO:BAR:CHANNEL" not in qtrace.curves_model
 
 
+def test_set_model_curves_empty(qtrace, get_test_file):
+    """Test that ArchiverCurveModel.set_model_curves() called with no arguments clears
+    the model
+
+    Parameters
+    ----------
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    get_test_file : fixture
+        A fixture used to get test files from the test_data directory
+
+    Expectations
+    ------------
+    The ArchiverCurveModel will have 1 curve
+    """
+    test_filename = get_test_file("test_file.trc")
+    test_data = loads(test_filename.read_text())
+
+    qtrace.curves_model.set_model_curves(test_data["curves"])
+    qtrace.curves_model.set_model_curves()
+
+    assert qtrace.curves_model.rowCount() == 1
+
+
 @pytest.mark.parametrize(
     ["column", "data_test", "data_expected"],
     [


### PR DESCRIPTION
Adding tests for `main.py`. Also adding tests for `ArchiverAxisModel.set_model_axes` and `ArchiverCurveModel.set_model_curves` for passing empty arguments.

The only fix that came up while writing tests was in `main.py`, changing `from subprocess import run` to `import subprocess`.