### PR TITLE
ENH: Data Insight Tool

### DIFF
--- a/trace/main.py
+++ b/trace/main.py
@@ -207,6 +207,7 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         return (input_file, startup_pvs)
 
     def open_data_insight_tool(self):
+        """Create a new instance of the Data Insight Tool"""
         dit = DataInsightTool(self, self.curves_model, self.ui.main_plot)
         dit.show()
 

--- a/trace/main.py
+++ b/trace/main.py
@@ -16,6 +16,7 @@ from pydm.utilities.macro import parse_macro_string
 from config import logger, datetime_pv
 from mixins import FileIOMixin, AxisTableMixin, PlotConfigMixin, TracesTableMixin
 from styles import CenterCheckStyle
+from widgets import DataInsightTool
 from trace_file_convert import PathAction
 
 
@@ -46,6 +47,8 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
             self.ui.cursor_scale_btn: -1,
         }
         self.ui.timespan_btns.buttonToggled.connect(self.set_plot_timerange)
+
+        self.ui.dit_btn.clicked.connect(self.open_data_insight_tool)
 
         # Toggle "Cursor" button on plot-mouse interaction
         multi_axis_plot = self.ui.main_plot.plotItem
@@ -202,6 +205,10 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         startup_pvs = list(dict.fromkeys(startup_pvs))
 
         return (input_file, startup_pvs)
+
+    def open_data_insight_tool(self):
+        dit = DataInsightTool(self, self.curves_model, self.ui.main_plot)
+        dit.show()
 
     @staticmethod
     def git_version():

--- a/trace/main.ui
+++ b/trace/main.ui
@@ -25,6 +25,13 @@
    <item>
     <layout class="QHBoxLayout" name="scale_ctrl_lyt">
      <item>
+      <widget class="QPushButton" name="dit_btn">
+       <property name="text">
+        <string>Data Insight Tool</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="scale_ctrl_spcr">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/trace/tests/conftest.py
+++ b/trace/tests/conftest.py
@@ -65,7 +65,7 @@ def qapp(qapp_args):
 
 
 @pytest.fixture
-def qtrace(qapp):
+def qtrace(qtbot, qapp):
     """Fixture for an instance of the TraceDisplay. Always uses an instance of
     PyDMApplication.
 
@@ -81,7 +81,7 @@ def qtrace(qapp):
 
     trace.close()
     qapp.processEvents()
-    del trace
+    trace.deleteLater()
 
 
 @pytest.fixture

--- a/trace/tests/test_widgets/test_archive_search.py
+++ b/trace/tests/test_widgets/test_archive_search.py
@@ -47,8 +47,8 @@ def test_archive_results_table_qtmodeltester(qtmodeltester, search_wid):
     ----------
     qtmodeltester : fixture
         pytest-qt fixture used for testing the validity of AbstractItemModels
-    qtrace : fixture
-        Instance of TraceDisplay for application testing
+    search_wid : fixture
+        Instance of ArchiveSearchWidget for application testing
 
     Expectations
     ------------

--- a/trace/tests/test_widgets/test_archive_search.py
+++ b/trace/tests/test_widgets/test_archive_search.py
@@ -21,7 +21,12 @@ def search_wid(qapp):
     """
     # Set PYDM_ARCHIVER_URL so tests have a predictable state
     with patch.dict(os.environ, {"PYDM_ARCHIVER_URL": DUMMY_ARCHIVER_URL}):
-        yield ArchiveSearchWidget()
+        asw = ArchiveSearchWidget()
+        yield asw
+
+    asw.close()
+    qapp.processEvents()
+    asw.deleteLater()
 
 
 def create_dummy_reply(data: bytes = b"", error_code=QNetworkReply.NoError):

--- a/trace/tests/test_widgets/test_data_insight_tool.py
+++ b/trace/tests/test_widgets/test_data_insight_tool.py
@@ -1,5 +1,6 @@
 import os
 import json
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import epics
@@ -12,6 +13,39 @@ from main import TraceDisplay
 from widgets.data_insight_tool import DataInsightTool
 
 DUMMY_ARCHIVER_URL = "dummy.archiver.url"
+
+
+CSV_TEST_DATA = (
+    "Address: KLYS:LI22:31:KVAC\nUnit: torr\nDescription: KLYS:LI22:31:KVAC.DESC\n"
+    + "Datetime,Value,Severity,Source\n6.0,100,NaN,Live\n7.0,101,NaN,Live\n"
+    + "8.0,102,NaN,Live\n9.0,103,NaN,Live\n10.0,104,NaN,Live\n"
+)
+JSON_TEST_DATA = json.dumps(
+    {
+        "meta": {"Address": "KLYS:LI22:31:KVAC", "Unit": "torr", "Description": "KLYS:LI22:31:KVAC.DESC"},
+        "data": [
+            {"Datetime": 6.0, "Value": 100, "Severity": "NaN", "Source": "Live"},
+            {"Datetime": 7.0, "Value": 101, "Severity": "NaN", "Source": "Live"},
+            {"Datetime": 8.0, "Value": 102, "Severity": "NaN", "Source": "Live"},
+            {"Datetime": 9.0, "Value": 103, "Severity": "NaN", "Source": "Live"},
+            {"Datetime": 10.0, "Value": 104, "Severity": "NaN", "Source": "Live"},
+        ],
+    },
+    indent=2,
+)
+
+
+ARCH_TEST_DATA = [
+    {
+        "data": [
+            {"secs": 1, "nanos": 0, "val": 95, "severity": 0},
+            {"secs": 2, "nanos": 0, "val": 96, "severity": 0},
+            {"secs": 3, "nanos": 0, "val": 97, "severity": 0},
+            {"secs": 4, "nanos": 0, "val": 98, "severity": 0},
+            {"secs": 5, "nanos": 0, "val": 99, "severity": 0},
+        ]
+    }
+]
 
 
 @pytest.fixture
@@ -28,10 +62,10 @@ def dit_wid(qtrace: TraceDisplay, monkeypatch, get_test_file):
 
     qtrace.curves_model.set_model_curves(test_data)
     curve_0 = qtrace.curves_model.curve_at_index(0)
-    curve_0.data = np.array([[6, 7, 8, 9], [100, 101, 102, 103, 104]])
+    curve_0.data_buffer = np.array([[6, 7, 8, 9, 10], [100, 101, 102, 103, 104]])
     curve_0.units = test_data[0]["yAxisName"]
     curve_1 = qtrace.curves_model.curve_at_index(1)
-    curve_1.data = np.array([[6, 7, 8, 9], [200, 201, 202, 203, 204]])
+    curve_1.data_buffer = np.array([[6, 7, 8, 9, 10], [200, 201, 202, 203, 204]])
 
     def mock_caget(address: str, *args, **kwargs):
         if address.endswith("EGU") or address.endswith(".DESC"):
@@ -81,21 +115,210 @@ def test_data_visualization_qtmodeltester(qtmodeltester, dit_wid):
     ["curve_ind", "expected_meta"], ((0, "torr, KLYS:LI22:31:KVAC.DESC"), (1, "KLYS:LI22:41:KVAC.DESC"))
 )
 def test_set_meta_data(dit_wid, curve_ind, expected_meta):
+    """Test DataInsightTool.set_meta_data() is successfully called when the selected
+    PV is changed, and that set_meta_data sets the meta data label to the correct value.
+
+    Parameters
+    ----------
+    dit_wid : fixture
+        Instance of DataInsightTool for application testing
+    curve_ind : int
+        The index to set as the current index of the PV Selection Combobox
+    expected_meta : str
+        The expected text for the meta data label
+
+    Expectations
+    ------------
+    DataInsightTool.meta_data_label should contain the expected text for the given index
+    """
     dit_wid.pv_select_box.setCurrentIndex(curve_ind)
     assert dit_wid.meta_data_label.text() == expected_meta
 
 
-def test_get_data(dit_wid):
-    pass
+@pytest.mark.parametrize(
+    ("extension", "expected_data"),
+    ((".csv", CSV_TEST_DATA), (".json", JSON_TEST_DATA)),
+)
+def test_export_data_success(dit_wid, tmp_path, extension, expected_data):
+    """Test DataVisualizationModel.export_data() successfully writes a file and it
+    matches the expected output.
+
+    Parameters
+    ----------
+    dit_wid : fixture
+        Instance of DataInsightTool for application testing
+    tmp_path : fixture
+         A fixture which will provide a temporary directory unique to each test function
+    extension : str
+        The file extension (and format) that to be exported
+    expected_data : str
+        The expected string value that should be saved in the exported file
+
+    Expectations
+    ------------
+    DataInsightTool and DataVisualizationModel will make a file with the expected name and content.
+    """
+    # Construct testcase
+    model_df = dit_wid.data_vis_model.df
+    model_df["Datetime"] = [6, 7, 8, 9, 10]
+    model_df["Datetime"] = model_df["Datetime"].apply(datetime.fromtimestamp, tz=timezone.utc)
+    model_df["Value"] = [100, 101, 102, 103, 104]
+    model_df["Severity"] = ["NaN"] * 5
+    model_df["Source"] = ["Live"] * 5
+    file = tmp_path / f"test_export_data_success{extension}"
+    dit_wid.data_vis_model.export_data(file, extension)
+
+    assert file.is_file()
+    assert file.read_text() == expected_data
 
 
-def test_export_data_to_file(dit_wid):
-    pass
+def test_export_data_dir(dit_wid, tmp_path):
+    """Test DataVisualizationModel.export_data() is interrupted when the provided filename
+    is a directory.
+
+    Parameters
+    ----------
+    dit_wid : fixture
+        Instance of DataInsightTool for application testing
+    tmp_path : fixture
+        A fixture which will provide a temporary directory unique to each test function
+
+    Expectations
+    ------------
+    No files/directories should be made and the logger should give a warning.
+    """
+    # Construct testcase
+    model_df = dit_wid.data_vis_model.df
+    model_df["Datetime"] = [6, 7, 8, 9, 10]
+    model_df["Datetime"] = model_df["Datetime"].apply(datetime.fromtimestamp, tz=timezone.utc)
+    model_df["Value"] = [100, 101, 102, 103, 104]
+    model_df["Severity"] = ["NaN"] * 5
+    model_df["Source"] = ["Live"] * 5
+
+    with pytest.raises(IsADirectoryError) as exc_info:
+        dit_wid.data_vis_model.export_data(tmp_path, "")
+    assert exc_info.type is IsADirectoryError
+
+    assert not tmp_path.is_file()
 
 
-def test_model_get_live_data(dit_wid):
-    pass
+def test_export_data_invalid_extension(dit_wid, tmp_path):
+    """Test DataVisualizationModel.export_data() is interrupted when the provided filename
+    has an extension other than *.csv, *.mat, or *.json . Needed to make a valid file after to prevent
+    a recursive loop.
+
+    Parameters
+    ----------
+    dit_wid : fixture
+        Instance of DataInsightTool for application testing
+    tmp_path : fixture
+        A fixture which will provide a temporary directory unique to each test function
+
+    Expectations
+    ------------
+    An error should be given when trying to make the *.xlsx file, but *.csv succeeds.
+    """
+    # Construct testcase
+    model_df = dit_wid.data_vis_model.df
+    model_df["Datetime"] = [6, 7, 8, 9, 10]
+    model_df["Datetime"] = model_df["Datetime"].apply(datetime.fromtimestamp, tz=timezone.utc)
+    model_df["Value"] = [100, 101, 102, 103, 104]
+    model_df["Severity"] = ["NaN"] * 5
+    model_df["Source"] = ["Live"] * 5
+
+    file_xlsx = tmp_path / "test_export_save_file_invalid_extension.xlsx"
+
+    with pytest.raises(ValueError) as exc_info:
+        dit_wid.data_vis_model.export_data(file_xlsx, ".xlsx")
+    assert exc_info.type is ValueError
+    assert not file_xlsx.is_file()
 
 
-def test_model_get_archive_data(dit_wid):
-    pass
+@pytest.mark.parametrize(
+    ("curve_ind", "x_range", "expected_data"),
+    (
+        (0, (5, 11), ([6, 7, 8, 9, 10], [100, 101, 102, 103, 104])),
+        (0, (7.5, 9.5), ([8, 9], [102, 103])),
+        (1, (6.5, 9.5), ([7, 8, 9], [201, 202, 203])),
+    ),
+)
+def test_model_set_live_data(dit_wid, curve_ind, x_range, expected_data):
+    """Test DataVisualizationModel.set_live_data() stores the correct data from
+    the curves_model into its DataFrame.
+
+    Parameters
+    ----------
+    dit_wid : fixture
+        Instance of DataInsightTool for application testing
+    curve_ind : int
+        The index corresponding to a curve in the curves_model
+    expected_data : tuple
+        The expected data to be stored in the Datetime and Value columns of the DataFrame
+
+    Expectations
+    ------------
+    DataVisualizationModel.df contains the expected Datetime and Value values for the given curve.
+    """
+    curve_item = dit_wid.curves_model.curve_at_index(curve_ind)
+    mod = dit_wid.data_vis_model
+    mod.set_live_data(curve_item, x_range)
+
+    assert mod.df["Datetime"].apply(datetime.timestamp).to_list() == expected_data[0]
+    assert mod.df["Value"].to_list() == expected_data[1]
+
+
+def test_model_get_archive_data_success(qtbot, dit_wid, mock_logger):
+    """Test DataVisualizationModel.get_archive_data() stores the correct data from
+    the Archiver Appliance into its DataFrame.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt window for widget testing
+    dit_wid : fixture
+        Instance of DataInsightTool for application testing
+    mock_logger : fixture
+        A fixture used for mocking the logger's warning and error methods
+
+    Expectations
+    ------------
+    DataVisualizationModel.recieve_archive_reply is emitted, logger.debug is not
+    called, and DataVisualizationModel.df contains the expected Datetime and Value
+    values for the given curve.
+    """
+    reply_str = json.dumps(ARCH_TEST_DATA).encode()
+    reply = create_dummy_reply(data=reply_str)
+
+    mod = dit_wid.data_vis_model
+
+    with qtbot.waitSignal(mod.reply_recieved, timeout=100):
+        mod.recieve_archive_reply(reply)
+
+    mock_logger.debug.assert_not_called()
+    assert mod.df["Datetime"].apply(datetime.timestamp).to_list() == [1, 2, 3, 4, 5]
+    assert mod.df["Value"].to_list() == [95, 96, 97, 98, 99]
+
+
+def test_model_get_archive_data_error(qtbot, dit_wid, mock_logger):
+    """Test DataVisualizationModel.get_archive_data() does nothing when an error
+    is recieved from the Archiver Appliance.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt window for widget testing
+    dit_wid : fixture
+        Instance of DataInsightTool for application testing
+    mock_logger : fixture
+        A fixture used for mocking the logger's warning and error methods
+
+    Expectations
+    ------------
+    DataVisualizationModel.recieve_archive_reply is emitted, logger.debug is called,
+    and DataVisualizationModel.df does not contain any extra data.
+    """
+    error_reply = create_dummy_reply(error_code=QNetworkReply.UnknownServerError)
+
+    with qtbot.waitSignal(dit_wid.data_vis_model.reply_recieved, timeout=100):
+        dit_wid.data_vis_model.recieve_archive_reply(error_reply)
+    mock_logger.debug.assert_called_once()

--- a/trace/tests/test_widgets/test_data_insight_tool.py
+++ b/trace/tests/test_widgets/test_data_insight_tool.py
@@ -1,0 +1,101 @@
+import os
+import json
+from unittest.mock import MagicMock, patch
+
+import epics
+import numpy as np
+import pytest
+from qtpy.QtCore import QByteArray
+from qtpy.QtNetwork import QNetworkReply
+
+from main import TraceDisplay
+from widgets.data_insight_tool import DataInsightTool
+
+DUMMY_ARCHIVER_URL = "dummy.archiver.url"
+
+
+@pytest.fixture
+def dit_wid(qtrace: TraceDisplay, monkeypatch, get_test_file):
+    """Fixture for an instance of the DataInsightTool.
+
+    Yields
+    ------
+    An instance of DataInsightTool.
+    """
+    # Populate the model with data and give the first curve a unit
+    test_filename = get_test_file("test_file.trc")
+    test_data = json.loads(test_filename.read_text())["curves"]
+
+    qtrace.curves_model.set_model_curves(test_data)
+    curve_0 = qtrace.curves_model.curve_at_index(0)
+    curve_0.data = np.array([[6, 7, 8, 9], [100, 101, 102, 103, 104]])
+    curve_0.units = test_data[0]["yAxisName"]
+    curve_1 = qtrace.curves_model.curve_at_index(1)
+    curve_1.data = np.array([[6, 7, 8, 9], [200, 201, 202, 203, 204]])
+
+    def mock_caget(address: str, *args, **kwargs):
+        if address.endswith("EGU") or address.endswith(".DESC"):
+            return address
+
+    monkeypatch.setattr(epics, "caget", mock_caget)
+
+    # Set PYDM_ARCHIVER_URL so tests have a predictable state
+    with patch.dict(os.environ, {"PYDM_ARCHIVER_URL": DUMMY_ARCHIVER_URL}):
+        yield DataInsightTool(qtrace, qtrace.curves_model, qtrace.ui.main_plot)
+
+
+def create_dummy_reply(data: bytes = b"", error_code=QNetworkReply.NoError):
+    """Helper function to create a mock QNetworkReply with specified data and error code.
+
+    Parameters
+    ----------
+    data : bytes
+        Data for the dummy QNetworkReply to return
+    error_code : QNetworkReply.NetworkError
+        Error code for the dummy QNetworkReply to return, default is QNetworkReply.NoError
+    """
+    reply = MagicMock(spec=QNetworkReply)
+    reply.error.return_value = error_code
+    reply.readAll.return_value = QByteArray(data)
+    return reply
+
+
+def test_data_visualization_qtmodeltester(qtmodeltester, dit_wid):
+    """Check the validity of the DataVisualizationModel with pytest-qt
+
+    Parameters
+    ----------
+    qtmodeltester : fixture
+        pytest-qt fixture used for testing the validity of AbstractItemModels
+    dit_wid : fixture
+        Instance of DataInsightTool for application testing
+
+    Expectations
+    ------------
+    qtmodeltester finds no issues with the model
+    """
+    qtmodeltester.check(dit_wid.data_vis_model, force_py=True)
+
+
+@pytest.mark.parametrize(
+    ["curve_ind", "expected_meta"], ((0, "torr, KLYS:LI22:31:KVAC.DESC"), (1, "KLYS:LI22:41:KVAC.DESC"))
+)
+def test_set_meta_data(dit_wid, curve_ind, expected_meta):
+    dit_wid.pv_select_box.setCurrentIndex(curve_ind)
+    assert dit_wid.meta_data_label.text() == expected_meta
+
+
+def test_get_data(dit_wid):
+    pass
+
+
+def test_export_data_to_file(dit_wid):
+    pass
+
+
+def test_model_get_live_data(dit_wid):
+    pass
+
+
+def test_model_get_archive_data(dit_wid):
+    pass

--- a/trace/tests/test_widgets/test_data_insight_tool.py
+++ b/trace/tests/test_widgets/test_data_insight_tool.py
@@ -9,8 +9,10 @@ import pytest
 from qtpy.QtCore import QByteArray
 from qtpy.QtNetwork import QNetworkReply
 
+from pydm.widgets.archiver_time_plot import ArchivePlotCurveItem
+
 from main import TraceDisplay
-from widgets.data_insight_tool import DataInsightTool
+from widgets.data_insight_tool import DataInsightTool, DataVisualizationModel
 
 DUMMY_ARCHIVER_URL = "dummy.archiver.url"
 
@@ -49,33 +51,53 @@ ARCH_TEST_DATA = [
 
 
 @pytest.fixture
-def dit_wid(qtrace: TraceDisplay, monkeypatch, get_test_file):
+def dit_wid(qtrace: TraceDisplay):
     """Fixture for an instance of the DataInsightTool.
 
     Yields
     ------
     An instance of DataInsightTool.
     """
-    # Populate the model with data and give the first curve a unit
-    test_filename = get_test_file("test_file.trc")
-    test_data = json.loads(test_filename.read_text())["curves"]
-
-    qtrace.curves_model.set_model_curves(test_data)
-    curve_0 = qtrace.curves_model.curve_at_index(0)
-    curve_0.data_buffer = np.array([[6, 7, 8, 9, 10], [100, 101, 102, 103, 104]])
-    curve_0.units = test_data[0]["yAxisName"]
-    curve_1 = qtrace.curves_model.curve_at_index(1)
-    curve_1.data_buffer = np.array([[6, 7, 8, 9, 10], [200, 201, 202, 203, 204]])
-
-    def mock_caget(address: str, *args, **kwargs):
-        if address.endswith("EGU") or address.endswith(".DESC"):
-            return address
-
-    monkeypatch.setattr(epics, "caget", mock_caget)
-
     # Set PYDM_ARCHIVER_URL so tests have a predictable state
     with patch.dict(os.environ, {"PYDM_ARCHIVER_URL": DUMMY_ARCHIVER_URL}):
-        yield DataInsightTool(qtrace, qtrace.curves_model, qtrace.ui.main_plot)
+        dit = DataInsightTool(qtrace, qtrace.curves_model, qtrace.ui.main_plot)
+        yield dit
+
+    dit.close()
+    dit.deleteLater()
+
+
+@pytest.fixture
+def dit_model():
+    """Fixture for an instance of the DataVisualizationModel.
+
+    Yields
+    ------
+    An instance of DataVisualizationModel.
+    """
+    dvm = DataVisualizationModel()
+    yield dvm
+    dvm.deleteLater()
+
+
+@pytest.fixture
+def mock_curve():
+    """Fixture for an instance of a mock ArchivePlotCurveItem object with preset
+    values for all attributes the DataVisualizationModel uses.
+
+    Yields
+    ------
+    An instance of ArchivePlotCurveItem.
+    """
+    curve_item = MagicMock(spec=ArchivePlotCurveItem)
+    curve_item.address = "KLYS:LI22:31:KVAC"
+    curve_item.units = "torr"
+    curve_item.min_x.return_value = 6
+    curve_item.max_x.return_value = 10
+    curve_item.getBufferSize.return_value = 5
+    curve_item.data_buffer = np.array([[6, 7, 8, 9, 10], [100, 101, 102, 103, 104]])
+
+    yield curve_item
 
 
 def create_dummy_reply(data: bytes = b"", error_code=QNetworkReply.NoError):
@@ -111,10 +133,7 @@ def test_data_visualization_qtmodeltester(qtmodeltester, dit_wid):
     qtmodeltester.check(dit_wid.data_vis_model, force_py=True)
 
 
-@pytest.mark.parametrize(
-    ["curve_ind", "expected_meta"], ((0, "torr, KLYS:LI22:31:KVAC.DESC"), (1, "KLYS:LI22:41:KVAC.DESC"))
-)
-def test_set_meta_data(dit_wid, curve_ind, expected_meta):
+def test_set_meta_data(dit_wid, mock_curve, monkeypatch):
     """Test DataInsightTool.set_meta_data() is successfully called when the selected
     PV is changed, and that set_meta_data sets the meta data label to the correct value.
 
@@ -122,31 +141,40 @@ def test_set_meta_data(dit_wid, curve_ind, expected_meta):
     ----------
     dit_wid : fixture
         Instance of DataInsightTool for application testing
-    curve_ind : int
-        The index to set as the current index of the PV Selection Combobox
-    expected_meta : str
-        The expected text for the meta data label
+    mock_curve : fixture
+        A mock curve object with preset values for all attributes the DataVisualizationModel uses
+    monkeypatch : fixture
+        To override epics.caget
 
     Expectations
     ------------
     DataInsightTool.meta_data_label should contain the expected text for the given index
     """
-    dit_wid.pv_select_box.setCurrentIndex(curve_ind)
-    assert dit_wid.meta_data_label.text() == expected_meta
+
+    def mock_caget(address: str, *args, **kwargs):
+        if address.endswith("EGU") or address.endswith(".DESC"):
+            return address
+
+    monkeypatch.setattr(epics, "caget", mock_caget)
+
+    dit_wid.data_vis_model.set_all_data(mock_curve, (6, 9))
+    dit_wid.set_meta_data()
+
+    assert dit_wid.meta_data_label.text() == "torr, KLYS:LI22:31:KVAC.DESC"
 
 
 @pytest.mark.parametrize(
     ("extension", "expected_data"),
     ((".csv", CSV_TEST_DATA), (".json", JSON_TEST_DATA)),
 )
-def test_export_data_success(dit_wid, tmp_path, extension, expected_data):
+def test_export_data_success(dit_model, tmp_path, extension, expected_data):
     """Test DataVisualizationModel.export_data() successfully writes a file and it
     matches the expected output.
 
     Parameters
     ----------
-    dit_wid : fixture
-        Instance of DataInsightTool for application testing
+    dit_model : fixture
+        Instance of DataVisualizationModel for application testing
     tmp_path : fixture
          A fixture which will provide a temporary directory unique to each test function
     extension : str
@@ -159,27 +187,30 @@ def test_export_data_success(dit_wid, tmp_path, extension, expected_data):
     DataInsightTool and DataVisualizationModel will make a file with the expected name and content.
     """
     # Construct testcase
-    model_df = dit_wid.data_vis_model.df
-    model_df["Datetime"] = [6, 7, 8, 9, 10]
-    model_df["Datetime"] = model_df["Datetime"].apply(datetime.fromtimestamp, tz=timezone.utc)
-    model_df["Value"] = [100, 101, 102, 103, 104]
-    model_df["Severity"] = ["NaN"] * 5
-    model_df["Source"] = ["Live"] * 5
+    dit_model.address = "KLYS:LI22:31:KVAC"
+    dit_model.unit = "torr"
+    dit_model.description = "KLYS:LI22:31:KVAC.DESC"
+    dit_model.df["Datetime"] = [6, 7, 8, 9, 10]
+    dit_model.df["Datetime"] = dit_model.df["Datetime"].apply(datetime.fromtimestamp, tz=timezone.utc)
+    dit_model.df["Value"] = [100, 101, 102, 103, 104]
+    dit_model.df["Severity"] = ["NaN"] * 5
+    dit_model.df["Source"] = ["Live"] * 5
+
     file = tmp_path / f"test_export_data_success{extension}"
-    dit_wid.data_vis_model.export_data(file, extension)
+    dit_model.export_data(file, extension)
 
     assert file.is_file()
     assert file.read_text() == expected_data
 
 
-def test_export_data_dir(dit_wid, tmp_path):
+def test_export_data_dir(dit_model, tmp_path):
     """Test DataVisualizationModel.export_data() is interrupted when the provided filename
     is a directory.
 
     Parameters
     ----------
-    dit_wid : fixture
-        Instance of DataInsightTool for application testing
+    dit_model : fixture
+        Instance of DataVisualizationModel for application testing
     tmp_path : fixture
         A fixture which will provide a temporary directory unique to each test function
 
@@ -188,29 +219,28 @@ def test_export_data_dir(dit_wid, tmp_path):
     No files/directories should be made and the logger should give a warning.
     """
     # Construct testcase
-    model_df = dit_wid.data_vis_model.df
-    model_df["Datetime"] = [6, 7, 8, 9, 10]
-    model_df["Datetime"] = model_df["Datetime"].apply(datetime.fromtimestamp, tz=timezone.utc)
-    model_df["Value"] = [100, 101, 102, 103, 104]
-    model_df["Severity"] = ["NaN"] * 5
-    model_df["Source"] = ["Live"] * 5
+    dit_model.df["Datetime"] = [6, 7, 8, 9, 10]
+    dit_model.df["Datetime"] = dit_model.df["Datetime"].apply(datetime.fromtimestamp, tz=timezone.utc)
+    dit_model.df["Value"] = [100, 101, 102, 103, 104]
+    dit_model.df["Severity"] = ["NaN"] * 5
+    dit_model.df["Source"] = ["Live"] * 5
 
     with pytest.raises(IsADirectoryError) as exc_info:
-        dit_wid.data_vis_model.export_data(tmp_path, "")
+        dit_model.export_data(tmp_path, "")
     assert exc_info.type is IsADirectoryError
 
     assert not tmp_path.is_file()
 
 
-def test_export_data_invalid_extension(dit_wid, tmp_path):
+def test_export_data_invalid_extension(dit_model, tmp_path):
     """Test DataVisualizationModel.export_data() is interrupted when the provided filename
     has an extension other than *.csv, *.mat, or *.json . Needed to make a valid file after to prevent
     a recursive loop.
 
     Parameters
     ----------
-    dit_wid : fixture
-        Instance of DataInsightTool for application testing
+    dit_model : fixture
+        Instance of DataVisualizationModel for application testing
     tmp_path : fixture
         A fixture which will provide a temporary directory unique to each test function
 
@@ -219,55 +249,54 @@ def test_export_data_invalid_extension(dit_wid, tmp_path):
     An error should be given when trying to make the *.xlsx file, but *.csv succeeds.
     """
     # Construct testcase
-    model_df = dit_wid.data_vis_model.df
-    model_df["Datetime"] = [6, 7, 8, 9, 10]
-    model_df["Datetime"] = model_df["Datetime"].apply(datetime.fromtimestamp, tz=timezone.utc)
-    model_df["Value"] = [100, 101, 102, 103, 104]
-    model_df["Severity"] = ["NaN"] * 5
-    model_df["Source"] = ["Live"] * 5
+    dit_model.df["Datetime"] = [6, 7, 8, 9, 10]
+    dit_model.df["Datetime"] = dit_model.df["Datetime"].apply(datetime.fromtimestamp, tz=timezone.utc)
+    dit_model.df["Value"] = [100, 101, 102, 103, 104]
+    dit_model.df["Severity"] = ["NaN"] * 5
+    dit_model.df["Source"] = ["Live"] * 5
 
     file_xlsx = tmp_path / "test_export_save_file_invalid_extension.xlsx"
 
     with pytest.raises(ValueError) as exc_info:
-        dit_wid.data_vis_model.export_data(file_xlsx, ".xlsx")
+        dit_model.export_data(file_xlsx, ".xlsx")
     assert exc_info.type is ValueError
     assert not file_xlsx.is_file()
 
 
 @pytest.mark.parametrize(
-    ("curve_ind", "x_range", "expected_data"),
+    ("x_range", "expected_data"),
     (
-        (0, (5, 11), ([6, 7, 8, 9, 10], [100, 101, 102, 103, 104])),
-        (0, (7.5, 9.5), ([8, 9], [102, 103])),
-        (1, (6.5, 9.5), ([7, 8, 9], [201, 202, 203])),
+        ((5, 11), ([6, 7, 8, 9, 10], [100, 101, 102, 103, 104])),
+        ((7.5, 9.5), ([8, 9], [102, 103])),
     ),
 )
-def test_model_set_live_data(dit_wid, curve_ind, x_range, expected_data):
+def test_model_set_live_data(dit_model, x_range, expected_data, mock_curve):
     """Test DataVisualizationModel.set_live_data() stores the correct data from
     the curves_model into its DataFrame.
 
     Parameters
     ----------
-    dit_wid : fixture
-        Instance of DataInsightTool for application testing
+    dit_model : fixture
+        Instance of DataVisualizationModel for application testing
     curve_ind : int
         The index corresponding to a curve in the curves_model
     expected_data : tuple
         The expected data to be stored in the Datetime and Value columns of the DataFrame
+    mock_curve : fixture
+        A mock curve object with preset values for all attributes the DataVisualizationModel uses
 
     Expectations
     ------------
     DataVisualizationModel.df contains the expected Datetime and Value values for the given curve.
     """
-    curve_item = dit_wid.curves_model.curve_at_index(curve_ind)
-    mod = dit_wid.data_vis_model
-    mod.set_live_data(curve_item, x_range)
 
-    assert mod.df["Datetime"].apply(datetime.timestamp).to_list() == expected_data[0]
-    assert mod.df["Value"].to_list() == expected_data[1]
+    dit_model.set_live_data(mock_curve, x_range)
+
+    assert dit_model.df["Datetime"].apply(datetime.timestamp).to_list() == expected_data[0]
+    assert dit_model.df["Value"].to_list() == expected_data[1]
 
 
-def test_model_get_archive_data_success(qtbot, dit_wid, mock_logger):
+def test_model_get_archive_data_success(qtbot, dit_model, mock_logger):
     """Test DataVisualizationModel.get_archive_data() stores the correct data from
     the Archiver Appliance into its DataFrame.
 
@@ -275,8 +304,8 @@ def test_model_get_archive_data_success(qtbot, dit_wid, mock_logger):
     ----------
     qtbot : fixture
         pytest-qt window for widget testing
-    dit_wid : fixture
-        Instance of DataInsightTool for application testing
+    dit_model : fixture
+        Instance of DataVisualizationModel for application testing
     mock_logger : fixture
         A fixture used for mocking the logger's warning and error methods
 
@@ -286,20 +315,19 @@ def test_model_get_archive_data_success(qtbot, dit_wid, mock_logger):
     called, and DataVisualizationModel.df contains the expected Datetime and Value
     values for the given curve.
     """
+    mock_logger.debug.reset_mock()
     reply_str = json.dumps(ARCH_TEST_DATA).encode()
     reply = create_dummy_reply(data=reply_str)
 
-    mod = dit_wid.data_vis_model
-
-    with qtbot.waitSignal(mod.reply_recieved, timeout=100):
-        mod.recieve_archive_reply(reply)
+    with qtbot.waitSignal(dit_model.reply_recieved, timeout=100):
+        dit_model.recieve_archive_reply(reply)
 
     mock_logger.debug.assert_not_called()
-    assert mod.df["Datetime"].apply(datetime.timestamp).to_list() == [1, 2, 3, 4, 5]
-    assert mod.df["Value"].to_list() == [95, 96, 97, 98, 99]
+    assert dit_model.df["Datetime"].apply(datetime.timestamp).to_list() == [1, 2, 3, 4, 5]
+    assert dit_model.df["Value"].to_list() == [95, 96, 97, 98, 99]
 
 
-def test_model_get_archive_data_error(qtbot, dit_wid, mock_logger):
+def test_model_get_archive_data_error(qtbot, dit_model, mock_logger):
     """Test DataVisualizationModel.get_archive_data() does nothing when an error
     is recieved from the Archiver Appliance.
 
@@ -307,8 +335,8 @@ def test_model_get_archive_data_error(qtbot, dit_wid, mock_logger):
     ----------
     qtbot : fixture
         pytest-qt window for widget testing
-    dit_wid : fixture
-        Instance of DataInsightTool for application testing
+    dit_model : fixture
+        Instance of DataVisualizationModel for application testing
     mock_logger : fixture
         A fixture used for mocking the logger's warning and error methods
 
@@ -317,8 +345,9 @@ def test_model_get_archive_data_error(qtbot, dit_wid, mock_logger):
     DataVisualizationModel.recieve_archive_reply is emitted, logger.debug is called,
     and DataVisualizationModel.df does not contain any extra data.
     """
+    mock_logger.debug.reset_mock()
     error_reply = create_dummy_reply(error_code=QNetworkReply.UnknownServerError)
 
-    with qtbot.waitSignal(dit_wid.data_vis_model.reply_recieved, timeout=100):
-        dit_wid.data_vis_model.recieve_archive_reply(error_reply)
+    with qtbot.waitSignal(dit_model.reply_recieved, timeout=100):
+        dit_model.recieve_archive_reply(error_reply)
     mock_logger.debug.assert_called_once()

--- a/trace/widgets/__init__.py
+++ b/trace/widgets/__init__.py
@@ -9,3 +9,4 @@ from .item_delegates import (
     InsertPVDelegate,
 )
 from .frozen_table_view import FrozenTableView
+from .data_insight_tool import DataInsightTool

--- a/trace/widgets/__init__.py
+++ b/trace/widgets/__init__.py
@@ -8,3 +8,4 @@ from .item_delegates import (
     ScientificNotationDelegate,
     InsertPVDelegate,
 )
+from .frozen_table_view import FrozenTableView

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -333,7 +333,8 @@ class DataInsightTool(QWidget):
         self.pv_select_box.currentIndexChanged.connect(self.get_data)
         self.refresh_button.clicked.connect(self.get_data)
 
-        self.get_data(0)
+        if self.pv_select_box.count() > 0:
+            self.get_data(0)
 
     def layout_init(self) -> None:
         """Initialize the layout of the Data Insight Tool widget."""
@@ -431,6 +432,10 @@ class DataInsightTool(QWidget):
         combobox_index : int, optional
             The index in the pv_select_box for the user selected curve, by default -1
         """
+        if self.pv_select_box.count() < 1:
+            logger.warning("Curves must be added to the main display before data can be requested.")
+            return
+
         curve_item = self.combobox_to_curve(combobox_index)
         x_range = self.plot.getXAxis().range
 

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -9,7 +9,6 @@ from datetime import datetime, timezone
 import epics
 import numpy as np
 import pandas as pd
-import tzlocal
 from scipy.io import savemat
 from qtpy.QtCore import (
     Qt,
@@ -41,7 +40,7 @@ from pydm.widgets.archiver_time_plot import (
 
 from widgets import FrozenTableView
 
-TZ = tzlocal.get_localzone()
+TZ = datetime.now().astimezone().tzinfo
 SEVERITY_MAP = {0: "NO_ALARM", 1: "MINOR", 2: "MAJOR", 3: "INVALID"}
 
 logger = logging.getLogger("")

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -6,10 +6,10 @@ from typing import Iterable
 from pathlib import Path
 from datetime import datetime, timezone
 
+import epics
 import numpy as np
 import pandas as pd
 import tzlocal
-from epics import caget
 from scipy.io import savemat
 from qtpy.QtCore import (
     Qt,
@@ -114,7 +114,7 @@ class DataVisualizationModel(QAbstractTableModel):
         """
         self.address = curve_item.address
         self.unit = curve_item.units
-        self.description = caget(curve_item.address + ".DESC")
+        self.description = epics.caget(curve_item.address + ".DESC")
 
         curve_range = (curve_item.min_x(), curve_item.max_x())
         left_ts = max(x_range[0], curve_range[0])

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -1,21 +1,25 @@
 import os
 import re
-import sys
 import json
 import logging
+from typing import Iterable
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
+import numpy as np
 import pandas as pd
+import tzlocal
+from epics import caget
 from scipy.io import savemat
 from qtpy.QtCore import (
     Qt,
     QUrl,
+    Slot,
     Signal,
     QObject,
     QModelIndex,
-    QStringListModel,
     QAbstractTableModel,
+    QSortFilterProxyModel,
 )
 from qtpy.QtNetwork import QNetworkReply, QNetworkRequest, QNetworkAccessManager
 from qtpy.QtWidgets import (
@@ -27,12 +31,17 @@ from qtpy.QtWidgets import (
     QMessageBox,
     QPushButton,
     QVBoxLayout,
-    QApplication,
 )
 
-# from widgets import FrozenTableView
-from frozen_table_view import FrozenTableView
+from pydm.widgets.archiver_time_plot import (
+    TimePlotCurveItem,
+    ArchivePlotCurveItem,
+    PyDMArchiverTimePlot,
+)
 
+from widgets import FrozenTableView
+
+TZ = tzlocal.get_localzone()
 SEVERITY_MAP = {0: "NO_ALARM", 1: "MINOR", 2: "MAJOR", 3: "INVALID"}
 
 logger = logging.getLogger("")
@@ -45,12 +54,15 @@ if not logger.hasHandlers():
     handler.setLevel("DEBUG")
 
 
-class ArchiveDataModel(QAbstractTableModel):
+class DataVisualizationModel(QAbstractTableModel):
     reply_recieved = Signal()
 
     def __init__(self, parent: QObject = None) -> None:
         super().__init__(parent)
-        self.df = pd.DataFrame(columns=["Datetime", "Value", "Severity", "Unit", "Source"])
+        self.df = pd.DataFrame(columns=["Datetime", "Value", "Severity", "Source"])
+
+        self.unit = None
+        self.description = None
 
         self.network_manager = QNetworkAccessManager()
         self.network_manager.finished.connect(self.recieve_archive_reply)
@@ -72,6 +84,44 @@ class ArchiveDataModel(QAbstractTableModel):
     def headerData(self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole = Qt.DisplayRole):
         if orientation == Qt.Horizontal and role == Qt.DisplayRole:
             return self.df.columns[section]
+
+    def set_all_data(self, curve_item: TimePlotCurveItem, x_range: Iterable[int]):
+        curve_range = (curve_item.min_x(), curve_item.max_x())
+        left_ts = max(x_range[0], curve_range[0])
+        right_ts = min(x_range[1], curve_range[1])
+
+        # Populate the model with live data if it is shown on the plot
+        if (curve_range[0] <= x_range[1]) and (x_range[0] <= curve_range[1]):
+            self.set_live_data(curve_item, (left_ts, right_ts))
+
+        # Populate the model with archive data if it is shown on the plot
+        if x_range[0] <= curve_range[0]:
+            from_dt = datetime.fromtimestamp(x_range[0], tz=timezone.utc)
+            to_dt = datetime.fromtimestamp(left_ts, tz=timezone.utc)
+            self.request_archive_data(curve_item.address, from_dt, to_dt)
+        else:
+            self.reply_recieved.emit()
+
+        self.unit = curve_item.units
+        self.description = caget(curve_item.address + ".DESC")
+
+    def set_live_data(self, curve_item: TimePlotCurveItem, ts_range: Iterable[int]):
+        data_n = curve_item.getBufferSize()
+        data = curve_item.data_buffer[:, :data_n]
+        indices = np.where((ts_range[0] <= data[0]) & (data[0] <= ts_range[1]))[0]
+
+        convert_data = {"Datetime": [], "Value": [], "Severity": []}
+        convert_data["Datetime"] = data[0, indices]
+        convert_data["Value"] = data[1, indices]
+        convert_data["Severity"] = ["NaN"] * indices.size
+        convert_data["Source"] = ["Live"] * indices.size
+
+        live_df = pd.DataFrame(convert_data)
+        live_df["Datetime"] = live_df["Datetime"].apply(datetime.fromtimestamp)
+
+        self.beginResetModel()
+        self.df = live_df
+        self.endResetModel()
 
     def request_archive_data(self, pv_name: str, from_dt: datetime, to_dt: datetime):
         from_date_str = from_dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
@@ -95,7 +145,7 @@ class ArchiveDataModel(QAbstractTableModel):
         if reply.error() == QNetworkReply.NoError:
             bytes_str = reply.readAll()
             data_dict = json.loads(str(bytes_str, "utf-8"))
-            self.set_all_data(data_dict)
+            self.set_archive_data(data_dict)
         else:
             logger.debug(
                 f"Request for data from archiver failed, request url: {reply.url()} retrieved header: "
@@ -103,22 +153,24 @@ class ArchiveDataModel(QAbstractTableModel):
             )
         reply.deleteLater()
 
-    def set_all_data(self, data_dict: dict):
+    def set_archive_data(self, data_dict: dict):
         convert_data = {"Datetime": [], "Value": [], "Severity": []}
         for point in data_dict[0]["data"]:
             ts = point["secs"] + (point["nanos"] * 1e-9)
             convert_data["Datetime"].append(datetime.fromtimestamp(ts))
             convert_data["Value"].append(point["val"])
             convert_data["Severity"].append(SEVERITY_MAP[point["severity"]])
-        try:
-            convert_data["Unit"] = [data_dict[0]["meta"]["EGU"]] * len(data_dict[0]["data"])
-        except KeyError:
-            logger.debug("Requested data has no unit.")
         convert_data["Source"] = ["Archive"] * len(data_dict[0]["data"])
+        archive_df = pd.DataFrame(convert_data)
 
-        self.beginResetModel()
-        self.df = pd.DataFrame(data=convert_data)
-        self.endResetModel()
+        if self.df.empty:
+            self.beginResetModel()
+            self.df = archive_df
+            self.endResetModel()
+        else:
+            self.beginInsertRows(QModelIndex(), 0, archive_df.shape[0] - 1)
+            self.df = pd.concat([archive_df, self.df])
+            self.endInsertRows()
         self.layoutChanged.emit()
 
     def export_data(self, file_name: Path, extension: str):
@@ -143,70 +195,67 @@ class ArchiveDataModel(QAbstractTableModel):
         self.df["Datetime"] = backup
 
 
+class CurveFilterModel(QSortFilterProxyModel):
+    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex):
+        curve = self.sourceModel().curve_at_index(source_row)
+        return isinstance(curve, ArchivePlotCurveItem) and bool(curve.address)
+
+
 class DataInsightTool(QWidget):
-    # def __init__(self, curve_model: QAbstractTableModel, parent: QObject = None) -> None:
-    def __init__(self, parent: QObject = None) -> None:
+    def __init__(self, parent: QObject, curves_model: QAbstractTableModel, plot: PyDMArchiverTimePlot) -> None:
         super().__init__(parent=parent)
         self.setWindowFlag(Qt.Window)
         self.resize(600, 600)
         self.setWindowTitle("Data Insight Tool")
 
-        if parent:
-            # Get curves model and plot
-            pass
-        else:
-            # Only for testing. Make dummy curves model and plot
-            self.curves_model = QStringListModel(
-                ["KLYS:LI22:31:KVAC", "SBST:LI29:1:AMPL", "LASR:IN20:196:PWR", "TPG:SYS0:1:MANUAL_PATH"]
-            )
+        # Get curves model and function for getting plot x-range
+        self.curves_model = curves_model
+        self.curve_filter_model = CurveFilterModel()
+        self.curve_filter_model.setSourceModel(self.curves_model)
+        self.plot = plot
 
-            def getXRange():
-                return [datetime(2024, 11, 17), datetime(2024, 11, 20)]
+        self.layout_init()
 
-            self.get_time_range = getXRange
-
-        self.init()
-
-        self.archive_data_model.reply_recieved.connect(self.loading_label.hide)
-        self.request_button.clicked.connect(self.get_data)
+        self.data_vis_model.reply_recieved.connect(self.loading_label.hide)
         self.export_button.clicked.connect(self.export_data_to_file)
+        self.pv_select_box.currentIndexChanged.connect(self.get_data)
+        self.refresh_button.clicked.connect(self.get_data)
 
-    def init(self):
+        self.get_data(0)
+
+    def layout_init(self):
         self.main_layout = QVBoxLayout()
 
         # Populate the PV selection and request layout at the top of the widget
         self.request_layout = QHBoxLayout()
         self.pv_select_box = QComboBox()
-        self.pv_select_box.setModel(self.curves_model)
+        self.pv_select_box.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self.pv_select_box.setModel(self.curve_filter_model)
         self.request_layout.addWidget(self.pv_select_box, alignment=Qt.AlignLeft)
 
         self.loading_label = QLabel("Loading...")
         self.loading_label.hide()
         self.request_layout.addWidget(self.loading_label, alignment=Qt.AlignCenter)
 
-        self.request_button = QPushButton("Request Data")
-        self.request_layout.addWidget(self.request_button, alignment=Qt.AlignRight)
+        self.export_button = QPushButton("Export to File")
+        self.request_layout.addWidget(self.export_button, alignment=Qt.AlignRight)
         self.main_layout.addLayout(self.request_layout)
 
+        # Create the metadata label and refresh button
+        self.metadata_layout = QHBoxLayout()
+        self.metadata_label = QLabel()
+        self.metadata_layout.addWidget(self.metadata_label, alignment=Qt.AlignLeft)
+
+        self.refresh_button = QPushButton("Refresh Data")
+        self.metadata_layout.addWidget(self.refresh_button, alignment=Qt.AlignRight)
+        self.main_layout.addLayout(self.metadata_layout)
+
         # Set up the main data table in the center of the widget
-        self.archive_data_model = ArchiveDataModel()
-        self.data_table = FrozenTableView(self.archive_data_model)
+        self.data_vis_model = DataVisualizationModel()
+        self.data_table = FrozenTableView(self.data_vis_model)
         self.main_layout.addWidget(self.data_table)
 
-        # Set up the export data layout at the bottom of the widget
-        self.export_layout = QHBoxLayout()
-        self.export_button = QPushButton("Export to File")
-        self.export_layout.addWidget(self.export_button, alignment=Qt.AlignRight)
-        self.main_layout.addLayout(self.export_layout)
-
         self.setLayout(self.main_layout)
-
-    def get_data(self):
-        pv_name = self.pv_select_box.currentText()
-        time_range = self.get_time_range()
-
-        self.archive_data_model.request_archive_data(pv_name, *time_range)
-        self.loading_label.show()
 
     def export_data_to_file(self):
         file_name, extension_filter = QFileDialog.getSaveFileName(
@@ -219,15 +268,26 @@ class DataInsightTool(QWidget):
         file_name = Path(file_name).with_suffix(extension)
 
         try:
-            self.archive_data_model.export_data(file_name, extension)
+            self.data_vis_model.export_data(file_name, extension)
         except (ValueError, IsADirectoryError) as e:
             logger.error(str(e))
             QMessageBox.critical(self, "Error", str(e))
 
+    def set_metadata(self):
+        meta_str = ""
+        if self.data_vis_model.unit:
+            meta_str = self.data_vis_model.unit + ", "
+        meta_str += self.data_vis_model.description
+        self.metadata_label.setText(meta_str)
 
-if __name__ == "__main__":
-    app = QApplication(sys.argv)
-    dit = DataInsightTool()
-    dit.show()
+    @Slot()
+    @Slot(int)
+    def get_data(self, curve_index: int = -1):
+        if curve_index < 0:
+            curve_index = self.pv_select_box.currentIndex()
+        curve_item = self.curves_model.curve_at_index(curve_index)
+        x_range = self.plot.getXAxis().range
 
-    app.exec_()
+        self.data_vis_model.set_all_data(curve_item, x_range)
+        self.set_metadata()
+        self.loading_label.show()

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -1,0 +1,233 @@
+import os
+import re
+import sys
+import json
+import logging
+from pathlib import Path
+from datetime import datetime
+
+import pandas as pd
+from scipy.io import savemat
+from qtpy.QtCore import (
+    Qt,
+    QUrl,
+    Signal,
+    QObject,
+    QModelIndex,
+    QStringListModel,
+    QAbstractTableModel,
+)
+from qtpy.QtNetwork import QNetworkReply, QNetworkRequest, QNetworkAccessManager
+from qtpy.QtWidgets import (
+    QLabel,
+    QWidget,
+    QComboBox,
+    QFileDialog,
+    QHBoxLayout,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QApplication,
+)
+
+# from widgets import FrozenTableView
+from frozen_table_view import FrozenTableView
+
+SEVERITY_MAP = {0: "NO_ALARM", 1: "MINOR", 2: "MAJOR", 3: "INVALID"}
+
+logger = logging.getLogger("")
+if not logger.hasHandlers():
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("[%(asctime)s] [%(levelname)-8s] - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel("DEBUG")
+    handler.setLevel("DEBUG")
+
+
+class ArchiveDataModel(QAbstractTableModel):
+    reply_recieved = Signal()
+
+    def __init__(self, parent: QObject = None) -> None:
+        super().__init__(parent)
+        self.df = pd.DataFrame(columns=["Datetime", "Value", "Severity", "Unit", "Source"])
+
+        self.network_manager = QNetworkAccessManager()
+        self.network_manager.finished.connect(self.recieve_archive_reply)
+
+    def rowCount(self, index: QModelIndex = QModelIndex()):
+        return self.df.shape[0]
+
+    def columnCount(self, index: QModelIndex = QModelIndex()):
+        return self.df.shape[1]
+
+    def data(self, index: QModelIndex, role: Qt.ItemDataRole = Qt.DisplayRole):
+        if not index.isValid():
+            return None
+        elif role == Qt.DisplayRole:
+            val = self.df.iat[index.row(), index.column()]
+            return str(val)
+        return None
+
+    def headerData(self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole = Qt.DisplayRole):
+        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
+            return self.df.columns[section]
+
+    def request_archive_data(self, pv_name: str, from_dt: datetime, to_dt: datetime):
+        from_date_str = from_dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+        to_date_str = to_dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+        base_url = os.getenv("PYDM_ARCHIVER_URL")
+        if base_url is None:
+            logger.error(
+                "Environment variable: PYDM_ARCHIVER_URL must be defined to use the archiver plugin, for "
+                "example: http://lcls-archapp.slac.stanford.edu"
+            )
+            return
+
+        url_string = f"{base_url}/retrieval/data/getData.json?pv={pv_name}&from={from_date_str}&to={to_date_str}"
+
+        request = QNetworkRequest(QUrl(url_string))
+        self.network_manager.get(request)
+
+    def recieve_archive_reply(self, reply: QNetworkReply):
+        self.reply_recieved.emit()
+        if reply.error() == QNetworkReply.NoError:
+            bytes_str = reply.readAll()
+            data_dict = json.loads(str(bytes_str, "utf-8"))
+            self.set_all_data(data_dict)
+        else:
+            logger.debug(
+                f"Request for data from archiver failed, request url: {reply.url()} retrieved header: "
+                f"{reply.header(QNetworkRequest.ContentTypeHeader)} error: {reply.error()}"
+            )
+        reply.deleteLater()
+
+    def set_all_data(self, data_dict: dict):
+        convert_data = {"Datetime": [], "Value": [], "Severity": []}
+        for point in data_dict[0]["data"]:
+            ts = point["secs"] + (point["nanos"] * 1e-9)
+            convert_data["Datetime"].append(datetime.fromtimestamp(ts))
+            convert_data["Value"].append(point["val"])
+            convert_data["Severity"].append(SEVERITY_MAP[point["severity"]])
+        try:
+            convert_data["Unit"] = [data_dict[0]["meta"]["EGU"]] * len(data_dict[0]["data"])
+        except KeyError:
+            logger.debug("Requested data has no unit.")
+        convert_data["Source"] = ["Archive"] * len(data_dict[0]["data"])
+
+        self.beginResetModel()
+        self.df = pd.DataFrame(data=convert_data)
+        self.endResetModel()
+        self.layoutChanged.emit()
+
+    def export_data(self, file_name: Path, extension: str):
+        if self.df.empty:
+            raise ValueError("No data to export. Request data first.")
+        if file_name.is_dir():
+            raise IsADirectoryError("The selected path is a directory. Select a file to export to.")
+        if extension not in [".csv", ".mat", ".json"]:
+            raise ValueError("Unrecognized file format requested. Skipping export.")
+
+        backup = self.df["Datetime"]
+        self.df["Datetime"] = self.df["Datetime"].astype("int64") / 1e9
+
+        if extension == ".csv":
+            self.df.to_csv(file_name, index=False)
+        elif extension == ".mat":
+            df_dict = {name: col.values for name, col in self.df.items()}
+            savemat(file_name, df_dict)
+        elif extension == ".json":
+            self.df.to_json(file_name, orient="records", indent=2)
+
+        self.df["Datetime"] = backup
+
+
+class DataInsightTool(QWidget):
+    # def __init__(self, curve_model: QAbstractTableModel, parent: QObject = None) -> None:
+    def __init__(self, parent: QObject = None) -> None:
+        super().__init__(parent=parent)
+        self.setWindowFlag(Qt.Window)
+        self.resize(600, 600)
+        self.setWindowTitle("Data Insight Tool")
+
+        if parent:
+            # Get curves model and plot
+            pass
+        else:
+            # Only for testing. Make dummy curves model and plot
+            self.curves_model = QStringListModel(
+                ["KLYS:LI22:31:KVAC", "SBST:LI29:1:AMPL", "LASR:IN20:196:PWR", "TPG:SYS0:1:MANUAL_PATH"]
+            )
+
+            def getXRange():
+                return [datetime(2024, 11, 17), datetime(2024, 11, 20)]
+
+            self.get_time_range = getXRange
+
+        self.init()
+
+        self.archive_data_model.reply_recieved.connect(self.loading_label.hide)
+        self.request_button.clicked.connect(self.get_data)
+        self.export_button.clicked.connect(self.export_data_to_file)
+
+    def init(self):
+        self.main_layout = QVBoxLayout()
+
+        # Populate the PV selection and request layout at the top of the widget
+        self.request_layout = QHBoxLayout()
+        self.pv_select_box = QComboBox()
+        self.pv_select_box.setModel(self.curves_model)
+        self.request_layout.addWidget(self.pv_select_box, alignment=Qt.AlignLeft)
+
+        self.loading_label = QLabel("Loading...")
+        self.loading_label.hide()
+        self.request_layout.addWidget(self.loading_label, alignment=Qt.AlignCenter)
+
+        self.request_button = QPushButton("Request Data")
+        self.request_layout.addWidget(self.request_button, alignment=Qt.AlignRight)
+        self.main_layout.addLayout(self.request_layout)
+
+        # Set up the main data table in the center of the widget
+        self.archive_data_model = ArchiveDataModel()
+        self.data_table = FrozenTableView(self.archive_data_model)
+        self.main_layout.addWidget(self.data_table)
+
+        # Set up the export data layout at the bottom of the widget
+        self.export_layout = QHBoxLayout()
+        self.export_button = QPushButton("Export to File")
+        self.export_layout.addWidget(self.export_button, alignment=Qt.AlignRight)
+        self.main_layout.addLayout(self.export_layout)
+
+        self.setLayout(self.main_layout)
+
+    def get_data(self):
+        pv_name = self.pv_select_box.currentText()
+        time_range = self.get_time_range()
+
+        self.archive_data_model.request_archive_data(pv_name, *time_range)
+        self.loading_label.show()
+
+    def export_data_to_file(self):
+        file_name, extension_filter = QFileDialog.getSaveFileName(
+            self,
+            "Export Archive Data",
+            Path(".").name,
+            "Comma-Separated Values File (*.csv);;MAT-File (*.mat);;JSON File (*.json)",
+        )
+        extension = re.search(r"\*(.*?)\)", extension_filter).group(1)
+        file_name = Path(file_name).with_suffix(extension)
+
+        try:
+            self.archive_data_model.export_data(file_name, extension)
+        except (ValueError, IsADirectoryError) as e:
+            logger.error(str(e))
+            QMessageBox.critical(self, "Error", str(e))
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    dit = DataInsightTool()
+    dit.show()
+
+    app.exec_()

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -73,19 +73,19 @@ class DataVisualizationModel(QAbstractTableModel):
         self.network_manager = QNetworkAccessManager()
         self.network_manager.finished.connect(self.recieve_archive_reply)
 
-    def rowCount(self, index: QModelIndex = QModelIndex()):
+    def rowCount(self, index: QModelIndex = QModelIndex()) -> int:
         """Return the row count of the table"""
         if index is not None and index.isValid():
             return 0
         return self.df.shape[0]
 
-    def columnCount(self, index: QModelIndex = QModelIndex()):
+    def columnCount(self, index: QModelIndex = QModelIndex()) -> int:
         """Return the column count of the table"""
         if index is not None and index.isValid():
             return 0
         return self.df.shape[1]
 
-    def data(self, index: QModelIndex, role: Qt.ItemDataRole = Qt.DisplayRole):
+    def data(self, index: QModelIndex, role: Qt.ItemDataRole = Qt.DisplayRole) -> str:
         """Return the data for the associated role. Currently only supporting DisplayRole."""
         if not index.isValid():
             return None
@@ -94,12 +94,12 @@ class DataVisualizationModel(QAbstractTableModel):
             return str(val)
         return None
 
-    def headerData(self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole = Qt.DisplayRole):
+    def headerData(self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole = Qt.DisplayRole) -> str:
         """Return data associated with the header"""
         if orientation == Qt.Horizontal and role == Qt.DisplayRole:
             return self.df.columns[section]
 
-    def set_all_data(self, curve_item: TimePlotCurveItem, x_range: Iterable[int]):
+    def set_all_data(self, curve_item: TimePlotCurveItem, x_range: Iterable[int]) -> None:
         """Set the model's data for the given curve and the given time range.
         This function determines what kind of data should be saved and prompts
         the methods for setting live or archived data as necessary. This also
@@ -131,7 +131,7 @@ class DataVisualizationModel(QAbstractTableModel):
             # Emulate network reply being recieved for parent widget
             self.reply_recieved.emit()
 
-    def set_live_data(self, curve_item: TimePlotCurveItem, x_range: Iterable[int]):
+    def set_live_data(self, curve_item: TimePlotCurveItem, x_range: Iterable[int]) -> None:
         """Set the live data for the given curve in the given time range. Appends
         rows within the time range to the end of the model's dataframe.
 
@@ -159,7 +159,7 @@ class DataVisualizationModel(QAbstractTableModel):
         self.df = live_df
         self.endResetModel()
 
-    def request_archive_data(self, pv_name: str, x_range: Iterable[int]):
+    def request_archive_data(self, pv_name: str, x_range: Iterable[int]) -> None:
         """Request data from the Archiver Appliance for the given PV and time range.
         Only gets raw data, never optimized. Ends early if there is no environment
         variable PYDM_ARCHIVER_URL, which would contain the url for the Archiver
@@ -193,7 +193,7 @@ class DataVisualizationModel(QAbstractTableModel):
         request = QNetworkRequest(QUrl(url_string))
         self.network_manager.get(request)
 
-    def recieve_archive_reply(self, reply: QNetworkReply):
+    def recieve_archive_reply(self, reply: QNetworkReply) -> None:
         """Process the recieved reply to the request made in request_archive_data.
         Unpack the data and call set_archive_data. Mostly checks if the reply
         contains an error.
@@ -215,7 +215,7 @@ class DataVisualizationModel(QAbstractTableModel):
             )
         reply.deleteLater()
 
-    def set_archive_data(self, data_dict: dict):
+    def set_archive_data(self, data_dict: dict) -> None:
         """Set the live data for the given curve in the given time range. Appends
         rows within the time range to the end of the model's dataframe.
 
@@ -243,7 +243,7 @@ class DataVisualizationModel(QAbstractTableModel):
             self.endInsertRows()
         self.layoutChanged.emit()
 
-    def export_data(self, file_path: Path, extension: str):
+    def export_data(self, file_path: Path, extension: str) -> None:
         """Export the model's data to the given file. Adds metadata to the top of
         the exported file with the curve's address, unit (if any), and description.
 
@@ -296,7 +296,7 @@ class CurveFilterModel(QSortFilterProxyModel):
     the curves without an address and the FormulaCurveItems.
     """
 
-    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex):
+    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:
         """Determine if the given row is valid and should be presented to the user.
         This includes ArchivePlotCurveItems that have an address.
 
@@ -336,7 +336,7 @@ class DataInsightTool(QWidget):
 
         self.get_data(0)
 
-    def layout_init(self):
+    def layout_init(self) -> None:
         """Initialize the layout of the Data Insight Tool widget."""
         self.main_layout = QVBoxLayout()
 
@@ -371,7 +371,7 @@ class DataInsightTool(QWidget):
 
         self.setLayout(self.main_layout)
 
-    def set_meta_data(self):
+    def set_meta_data(self) -> None:
         """Populate the meta_data_label with the curve's unit (if any) and description."""
         meta_str = ""
         if self.data_vis_model.unit:
@@ -400,7 +400,7 @@ class DataInsightTool(QWidget):
         return self.curves_model.curve_at_index(corrected_ind)
 
     @Slot()
-    def export_data_to_file(self):
+    def export_data_to_file(self) -> None:
         """Prompt the user to select a file to export data to then prompt the
         DataVisualizationModel to export its data to the selected file.
         """
@@ -423,7 +423,7 @@ class DataInsightTool(QWidget):
 
     @Slot()
     @Slot(int)
-    def get_data(self, combobox_index: int = -1):
+    def get_data(self, combobox_index: int = -1) -> None:
         """Prompt the DataVisualizationModel to fetch and save the data for the
         curve chosen by the user for the time range on the associated plot.
 

--- a/trace/widgets/frozen_table_view.py
+++ b/trace/widgets/frozen_table_view.py
@@ -1,0 +1,86 @@
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QTableView, QHeaderView
+
+
+class FrozenTableView(QTableView):
+    """QTableView with the leftmost column frozen so it always shows while the
+    rest of the table is horizontally scrollable.
+
+    Python version of Qt FreezeTableWidget example:
+    https://doc.qt.io/qt-6/qtwidgets-itemviews-frozencolumn-example.html
+    """
+
+    def __init__(self, model):
+        super(FrozenTableView, self).__init__()
+        self.setModel(model)
+        self.frozenTableView = QTableView(self)
+        self.init()
+        self.horizontalHeader().sectionResized.connect(self.updateSectionWidth)
+        self.verticalHeader().hide()
+        self.frozenTableView.verticalScrollBar().valueChanged.connect(self.verticalScrollBar().setValue)
+        self.verticalScrollBar().valueChanged.connect(self.frozenTableView.verticalScrollBar().setValue)
+
+    def init(self):
+        self.frozenTableView.setModel(self.model())
+        self.frozenTableView.setFocusPolicy(Qt.NoFocus)
+        self.frozenTableView.verticalHeader().hide()
+        self.frozenTableView.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+        self.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+        self.viewport().stackUnder(self.frozenTableView)
+
+        self.setAlternatingRowColors(True)
+        self.frozenTableView.setAlternatingRowColors(True)
+        self.frozenTableView.setStyleSheet("QTableView {border: none; border-right: 1px solid lightGray}")
+
+        self.setSelectionBehavior(QTableView.SelectRows)
+        self.frozenTableView.setSelectionBehavior(QTableView.SelectRows)
+        self.frozenTableView.setSelectionModel(self.selectionModel())
+        for col in range(1, self.model().columnCount()):
+            self.frozenTableView.setColumnHidden(col, True)
+        self.frozenTableView.setColumnWidth(0, self.columnWidth(0))
+        self.frozenTableView.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.frozenTableView.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.frozenTableView.show()
+        self.updateFrozenTableGeometry()
+        self.setHorizontalScrollMode(self.ScrollPerPixel)
+        self.setVerticalScrollMode(self.ScrollPerPixel)
+        self.frozenTableView.setVerticalScrollMode(self.ScrollPerPixel)
+
+    def updateSectionWidth(self, logicalIndex, oldSize, newSize):
+        if logicalIndex == 0:
+            self.frozenTableView.setColumnWidth(0, newSize)
+            self.updateFrozenTableGeometry()
+
+    def updateSectionHeight(self, logicalIndex, oldSize, newSize):
+        self.frozenTableView.setRowHeight(logicalIndex, newSize)
+
+    def resizeEvent(self, event):
+        super(FrozenTableView, self).resizeEvent(event)
+        self.updateFrozenTableGeometry()
+
+    def moveCursor(self, cursorAction, modifiers):
+        current = super(FrozenTableView, self).moveCursor(cursorAction, modifiers)
+        if (
+            cursorAction == self.MoveLeft
+            and current.column() > 0
+            and self.visualRect(current).topLeft().x() < self.frozenTableView.columnWidth(0)
+        ):
+            newValue = (
+                self.horizontalScrollBar().value()
+                + self.visualRect(current).topLeft().x()
+                - self.frozenTableView.columnWidth(0)
+            )
+            self.horizontalScrollBar().setValue(newValue)
+        return current
+
+    def scrollTo(self, index, hint):
+        if index.column() > 0:
+            super(FrozenTableView, self).scrollTo(index, hint)
+
+    def updateFrozenTableGeometry(self):
+        self.frozenTableView.setGeometry(
+            self.verticalHeader().width() + self.frameWidth(),
+            self.frameWidth(),
+            self.columnWidth(0),
+            self.viewport().height() + self.horizontalHeader().height(),
+        )


### PR DESCRIPTION
Created a tool to view and export all data points shown on the plot. As of right now, the method of opening the tool is just a button on the top left of the main display labeled "Data Insight Tool". This should probably be moved somewhere else, but I'm not sure where.

The widget consists of 4 main widgets:
1. The PV Selection Combobox
  a. Only shows PVs for ArchiverPlotCurveItems (does not work for FormulaCurveItems yet)
2. Refresh Data Button
  a. Useful for if the range on the plot's x-axis changes. Prompt's data fetching as needed.
3. Export Data Button
  a. Prompts user to select a file and format to write the data to.
  b. Allows for .csv, .mat, & .json as of right now
4. TableView
  a. Shows all the data as well as its source (live or archive)
  b. The leftmost column is the datetime in ISO 8601 format. This column is frozen so that it is always shown, regardless of how far right the user scrolls

The widget only shows data for one curve at a time, but users can open multiple instances of this tool to see data for multiple curves in separate windows.

Future development:
- Add sorting & filtering to TableView
- Add FormulaCurveItem capabilities
- Add alarm status for live data once that is collected