### PR TITLE
FIX: Delete removed curves

### DIFF
--- a/trace/table_models/curve_model.py
+++ b/trace/table_models/curve_model.py
@@ -505,9 +505,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         self._plot.set_needs_redraw()
         self._plot.redrawPlot()
         logger.debug(f"Finished removing curve previously at index {index.row()}")
-        self._plot.archive_data_received()
-        self._plot.set_needs_redraw()
-        self._plot.redrawPlot()
+        curve.deleteLater()
         return ret
 
     def headerData(self, section, orientation, role=Qt.DisplayRole) -> Any:


### PR DESCRIPTION
Delete removed curves. Wasn't implemented before so the curves just persist in purgatory.

Also, I can't remember the reasoning behind redrawing the plot multiple times. Seems unnecessary. Removing it for now.