### PR TITLE
FIX: Fixing mouse mode to enable panning

### DIFF
--- a/trace/mixins/plot_config.py
+++ b/trace/mixins/plot_config.py
@@ -33,7 +33,7 @@ class PlotConfigMixin:
 
         self.ui.crosshair_chckbx.stateChanged.connect(lambda show: self.plot.enableCrosshair(show, 100, 100))
 
-        self.ui.mouse_mode_cmbbx.currentTextChanged.connect(self.changeMouseMode)
+        self.ui.mouse_mode_cmbbx.currentTextChanged.connect(self.plot.plotItem.changeMouseMode)
 
     def plot_setup(self, config: Dict):
         """Read in the full config dictionary, making sure not to fail if a user manually typed
@@ -63,11 +63,6 @@ class PlotConfigMixin:
         font = QFont()
         font.setPixelSize(size)
         self.plot.getAxis("bottom").setStyle(tickFont=font)
-
-    @Slot(str)
-    def changeMouseMode(self, mode: str):
-        """If the user wants to have their mouse in PAN or RECT mode"""
-        self.plot.plotItem.changeMouseMode(mode)
 
     @Slot()
     def autoScroll(self, enable: bool = False):

--- a/trace/mixins/plot_config.py
+++ b/trace/mixins/plot_config.py
@@ -1,6 +1,5 @@
 from typing import Dict
 
-from pyqtgraph import ViewBox
 from qtpy.QtGui import QFont, QColor
 from qtpy.QtCore import Slot
 
@@ -34,7 +33,7 @@ class PlotConfigMixin:
 
         self.ui.crosshair_chckbx.stateChanged.connect(lambda show: self.plot.enableCrosshair(show, 100, 100))
 
-        self.ui.mouse_mode_cmbbx.currentIndexChanged.connect(self.changeMouseMode)
+        self.ui.mouse_mode_cmbbx.currentTextChanged.connect(self.changeMouseMode)
 
     def plot_setup(self, config: Dict):
         """Read in the full config dictionary, making sure not to fail if a user manually typed
@@ -65,13 +64,10 @@ class PlotConfigMixin:
         font.setPixelSize(size)
         self.plot.getAxis("bottom").setStyle(tickFont=font)
 
-    @Slot(int)
-    def changeMouseMode(self, mode: int):
+    @Slot(str)
+    def changeMouseMode(self, mode: str):
         """If the user wants to have their mouse in PAN or RECT mode"""
-        mouse_mode = ViewBox.RectMode
-        if mode == 1:
-            mouse_mode = ViewBox.PanMode
-        self.plot.plotItem.getViewBox().setMouseMode(mouse_mode)
+        self.plot.plotItem.changeMouseMode(mode)
 
     @Slot()
     def autoScroll(self, enable: bool = False):


### PR DESCRIPTION
Fixing Trace's mouse mode feature in the Plot Config tab. The problem was that it was only setting the mouse mode for the main viewbox of the plot and not all of them.

This makes sure to use the multi-axis-viewbox's method for changing mouse mode.