### PR TITLE
ENH: Implement button to manually trigger archive fetch

### DIFF
--- a/trace/main.py
+++ b/trace/main.py
@@ -52,6 +52,7 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
 
         self.ui.dit_btn.clicked.connect(self.open_data_insight_tool)
         self.ui.save_img_btn.clicked.connect(self.save_plot_image)
+        self.ui.fetch_archive_btn.clicked.connect(self.fetch_archive)
 
         # Toggle "Cursor" button on plot-mouse interaction
         multi_axis_plot = self.ui.main_plot.plotItem
@@ -214,7 +215,7 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         dit = DataInsightTool(self, self.curves_model, self.ui.main_plot)
         dit.show()
 
-    def save_plot_image(self):
+    def save_plot_image(self) -> None:
         """Saves current plot as an image. Opens file dialog to allow user to
         set custom location."""
         exporter = pyqtgraph.exporters.ImageExporter(self.ui.main_plot.plotItem)
@@ -232,6 +233,14 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
                 logger.info(f"Saved image file to: {file_path}")
             except Exception as e:
                 logger.error(f"Failed to save image: {e}")
+
+    def fetch_archive(self) -> None:
+        """Triggers a fetch to the archive"""
+        if not (self.ui.main_plot._archive_request_queued):
+            logger.info("Requesting data from archiver")
+            self.ui.main_plot.requestDataFromArchiver()
+        else:
+            logger.info("Archive fetch is already queued")
 
     @staticmethod
     def git_version():

--- a/trace/main.ui
+++ b/trace/main.ui
@@ -39,6 +39,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="fetch_archive_btn">
+       <property name="text">
+        <string>Fetch Archive</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="scale_ctrl_spcr">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/trace/tests/conftest.py
+++ b/trace/tests/conftest.py
@@ -95,4 +95,5 @@ def mock_logger():
     logger.debug = mock.Mock()
     logger.warning = mock.Mock()
     logger.error = mock.Mock()
+    logger.info = mock.Mock()
     yield logger

--- a/trace/tests/test_main.py
+++ b/trace/tests/test_main.py
@@ -188,7 +188,7 @@ def test_fetch_archive_button_success(qtbot, qtrace):
     with qtbot.waitSignal(fetch_archive_button.clicked, timeout=100):
         fetch_archive_button.click()
 
-    assert qtrace.ui.main_plot._archive_request_queued == True
+    assert qtrace.ui.main_plot._archive_request_queued is True
 
 
 def test_fetch_archive_button_duplicate(qtbot, qtrace, mock_logger):

--- a/trace/tests/test_main.py
+++ b/trace/tests/test_main.py
@@ -151,6 +151,9 @@ def test_save_image_button_error(mock_get_save_filename, mock_export, qtbot, qtr
         pytest-qt window for widget testing
     qtrace : fixture
         Instance of TraceDisplay for application testing
+    mock_logger: fixture
+        Mock logger
+
 
     Expectations
     ------------
@@ -163,6 +166,54 @@ def test_save_image_button_error(mock_get_save_filename, mock_export, qtbot, qtr
         save_image_button.click()
 
     mock_logger.error.assert_called_with("Failed to save image: Export failed!")
+
+
+def test_fetch_archive_button_success(qtbot, qtrace):
+    """Test fetch archive button correctly prompts for archive request
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt window for widget testing
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+
+
+    Expectations
+    ------------
+    When the button is clicked, an archive data request is queued and the flag is set to True.
+    """
+    fetch_archive_button = qtrace.ui.fetch_archive_btn
+
+    with qtbot.waitSignal(fetch_archive_button.clicked, timeout=100):
+        fetch_archive_button.click()
+
+    assert qtrace.ui.main_plot._archive_request_queued == True
+
+
+def test_fetch_archive_button_duplicate(qtbot, qtrace, mock_logger):
+    """Test fetch archive button doesn't make an additional request if a request is already queued
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt window for widget testing
+    qtrace : fixture
+        Instance of TraceDisplay for application testing
+    mock_logger: fixture
+        Mock logger
+
+    Expectations
+    ------------
+    When the button is clicked, but there is already a request, a duplicate shouldn't be done.
+    """
+    fetch_archive_button = qtrace.ui.fetch_archive_btn
+    qtrace.ui.main_plot._archive_request_queued = True
+
+    with qtbot.waitSignal(fetch_archive_button.clicked, timeout=100):
+        fetch_archive_button.click()
+
+    mock_logger.info.assert_called_with("Archive fetch is already queued")
 
 
 def test_click_toggled_timespan_button(qtbot, qtrace):


### PR DESCRIPTION
Adds a "fetch archive" button to allow user to manually prompt for archive fetch.

It checks to see if there is already a request queued.

![image](https://github.com/user-attachments/assets/57e66801-beee-4278-ab06-1f67c4e597e5)
