### PR TITLE
ENH: Enable plot's extension lines

### DIFF
--- a/trace/main.py
+++ b/trace/main.py
@@ -58,6 +58,8 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         multi_axis_plot.vb.menu = None
         multi_axis_plot.sigXRangeChangedManually.connect(self.ui.cursor_scale_btn.toggle)
 
+        self.ui.main_plot.show_extension_lines = True
+
         # Parse macros & arguments, then include them in startup
         input_file, startup_pvs = self.parse_macros_and_args(macros, args)
         if input_file:


### PR DESCRIPTION
Displays a line extending from a curve's rightmost point (latest) to infinity. This way the user will always see the curve's latest point, even if its data hasn't changed in a long time.

Relies on https://github.com/slaclab/pydm/pull/1167