### PR TITLE
ENH: Begin Trace Redesign

### DIFF
--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -1,0 +1,260 @@
+import os
+import subprocess
+from socket import gethostname
+from getpass import getuser
+
+from qtpy.QtGui import QFont
+from qtpy.QtCore import Qt, QSize
+from qtpy.QtWidgets import (
+    QLabel,
+    QWidget,
+    QLineEdit,
+    QSplitter,
+    QTreeView,
+    QHBoxLayout,
+    QPushButton,
+    QSizePolicy,
+    QSpacerItem,
+    QVBoxLayout,
+    QApplication,
+    QButtonGroup,
+)
+
+from pydm import Display
+from pydm.widgets import PyDMLabel, PyDMArchiverTimePlot
+
+from config import datetime_pv
+
+
+class TraceDisplay(Display):
+    def __init__(self, parent=None, args=None, macros=None) -> None:
+        super(TraceDisplay, self).__init__(parent=parent, args=args, macros=macros, ui_filename=None)
+        self.build_ui()
+        self.setup_ui()
+        self.configure_app()
+        self.resize(1100, 700)
+
+    def minimumSizeHint(self):
+        return QSize(700, 350)
+
+    def build_ui(self) -> None:
+        # Set window title
+        self.setWindowTitle("Trace")
+        # Create main layout
+        main_layout = QVBoxLayout()
+        self.setLayout(main_layout)
+
+        # Create the plotting and control widgets
+        plot_side_widget = self.build_plot_side(self)
+        control_side_widget = self.build_control_side(self)
+
+        # Create main splitter
+        main_splitter = QSplitter(self)
+        main_splitter.addWidget(plot_side_widget)
+        main_splitter.addWidget(control_side_widget)
+        main_splitter.setSizes([1, 300])
+        main_splitter.setCollapsible(0, False)
+        main_splitter.setStretchFactor(0, 1)
+        main_layout.addWidget(main_splitter)
+
+        # Create the footer section of the app
+        footer_widget = self.build_footer(self)
+        main_layout.addWidget(footer_widget)
+
+    def build_plot_side(self, parent):
+        plot_side_widget = QWidget(parent)
+        plot_side_layout = QVBoxLayout()
+        plot_side_widget.setLayout(plot_side_layout)
+
+        toolbar = self.build_toolbar(plot_side_widget)
+        plot_side_layout.addLayout(toolbar)
+
+        # Create plot
+        self.main_plot = PyDMArchiverTimePlot(plot_side_widget, background="white", optimized_data_bins=5000)
+        plot_side_layout.addWidget(self.main_plot)
+
+        return plot_side_widget
+
+    def build_toolbar(self, parent):
+        toolbar_widget = QWidget(parent)
+        # Create tool layout
+        tool_layout = QHBoxLayout()
+        save_image_button = QPushButton("Save Image", toolbar_widget)
+        tool_layout.addWidget(save_image_button)
+        logger_button = QPushButton("Logger", toolbar_widget)
+        tool_layout.addWidget(logger_button)
+        tool_spacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        tool_layout.addSpacerItem(tool_spacer)
+        timespan_buttons = self.build_timespan_buttons(toolbar_widget)
+        tool_layout.addWidget(timespan_buttons)
+        data_insight_tool_button = QPushButton("Data Insight Tool", toolbar_widget)
+        tool_layout.addWidget(data_insight_tool_button)
+
+        return toolbar_widget
+
+    def build_timespan_buttons(self, parent: QWidget):
+        timespan_button_widget = QWidget(parent)
+        timespan_button_layout = QHBoxLayout()
+        timespan_button_layout.setContentsMargins(0, 0, 0, 0)
+        timespan_button_widget.setLayout(timespan_button_layout)
+
+        self.min_scale_btn = QPushButton("1m", timespan_button_widget)
+        self.min_scale_btn.setMaximumWidth(40)
+        self.min_scale_btn.setCheckable(True)
+        timespan_button_layout.addWidget(self.min_scale_btn)
+
+        self.hour_scale_btn = QPushButton("1h", timespan_button_widget)
+        self.hour_scale_btn.setMaximumWidth(40)
+        self.hour_scale_btn.setCheckable(True)
+        self.hour_scale_btn.setChecked(True)
+        timespan_button_layout.addWidget(self.hour_scale_btn)
+
+        self.day_scale_btn = QPushButton("1d", timespan_button_widget)
+        self.day_scale_btn.setMaximumWidth(40)
+        self.day_scale_btn.setCheckable(True)
+        timespan_button_layout.addWidget(self.day_scale_btn)
+
+        self.week_scale_btn = QPushButton("1w", timespan_button_widget)
+        self.week_scale_btn.setMaximumWidth(40)
+        self.week_scale_btn.setCheckable(True)
+        timespan_button_layout.addWidget(self.week_scale_btn)
+
+        self.month_scale_btn = QPushButton("1M", timespan_button_widget)
+        self.month_scale_btn.setMaximumWidth(40)
+        self.month_scale_btn.setCheckable(True)
+        timespan_button_layout.addWidget(self.month_scale_btn)
+
+        # Create timespan button group
+        timespan_buttons = QButtonGroup(timespan_button_widget)
+        timespan_buttons.setExclusive(True)
+        timespan_buttons.addButton(self.min_scale_btn)
+        timespan_buttons.addButton(self.hour_scale_btn)
+        timespan_buttons.addButton(self.day_scale_btn)
+        timespan_buttons.addButton(self.week_scale_btn)
+        timespan_buttons.addButton(self.month_scale_btn)
+
+        return timespan_button_widget
+
+    def build_control_side(self, parent):
+        # Create right layout
+        control_side_widget = QWidget(parent)
+        control_side_layout = QVBoxLayout()
+        control_side_widget.setLayout(control_side_layout)
+
+        # Create pv plotter layout
+        pv_plotter_layout = QHBoxLayout()
+        control_side_layout.addLayout(pv_plotter_layout)
+        pv_line_edit = QLineEdit("Enter PV", control_side_widget)
+        pv_plotter_layout.addWidget(pv_line_edit)
+        pv_plot_button = QPushButton("Plot", control_side_widget)
+        pv_plotter_layout.addWidget(pv_plot_button)
+
+        # Create axis & curve view
+        axis_view = QTreeView(control_side_widget)
+        control_side_layout.addWidget(axis_view)
+        new_axis_button = QPushButton("New Axis", control_side_widget)
+        control_side_layout.addWidget(new_axis_button)
+
+        return control_side_widget
+
+    def build_footer(self, parent: QWidget):
+        label_font = QFont()
+        label_font.setPointSize(8)
+
+        footer_widget = QWidget(parent)
+        # footer_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        footer_widget.setFixedHeight(12)
+        footer_layout = QHBoxLayout()
+        footer_layout.setContentsMargins(0, 0, 0, 0)
+        footer_widget.setLayout(footer_layout)
+
+        self.version_label = QLabel("<version_tag>", footer_widget)
+        self.version_label.setFont(label_font)
+        self.version_label.setToolTip("Trace Version")
+        self.version_label.setAlignment(Qt.AlignBottom)
+        footer_layout.addWidget(self.version_label)
+        footer_layout.addWidget(BreakerLabel(footer_widget))
+
+        self.node_label = QLabel("<node_name>", footer_widget)
+        self.node_label.setFont(label_font)
+        self.node_label.setToolTip("Node Name")
+        self.node_label.setAlignment(Qt.AlignBottom)
+        footer_layout.addWidget(self.node_label)
+        footer_layout.addWidget(BreakerLabel(footer_widget))
+
+        self.user_label = QLabel("<user>", footer_widget)
+        self.user_label.setFont(label_font)
+        self.user_label.setToolTip("User Name")
+        self.user_label.setAlignment(Qt.AlignBottom)
+        footer_layout.addWidget(self.user_label)
+        footer_layout.addWidget(BreakerLabel(footer_widget))
+
+        self.pid_label = QLabel("<PID>", footer_widget)
+        self.pid_label.setFont(label_font)
+        self.pid_label.setToolTip("PID")
+        self.pid_label.setAlignment(Qt.AlignBottom)
+        footer_layout.addWidget(self.pid_label)
+        footer_layout.addWidget(BreakerLabel(footer_widget))
+
+        self.url_label = QLabel("<PYDM_ARCHIVER_URL>", footer_widget)
+        self.url_label.setFont(label_font)
+        self.url_label.setToolTip("Archiver URL")
+        self.url_label.setAlignment(Qt.AlignBottom)
+        footer_layout.addWidget(self.url_label)
+
+        footer_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        footer_layout.addSpacerItem(footer_spacer)
+
+        self.time_label = PyDMLabel(footer_widget, f"ca://{datetime_pv}")
+        self.time_label.setAlignment(Qt.AlignBottom)
+        footer_layout.addWidget(self.time_label)
+
+        return footer_widget
+
+    def setup_ui(self):
+        self.setup_footer()
+
+    def setup_footer(self):
+        """Set footer information for application. Includes logging, nodename,
+        username, PID, git version, Archiver URL, and current datetime
+        """
+        self.version_label.setText(self.git_version())
+        self.node_label.setText(gethostname())
+        self.user_label.setText(getuser())
+        self.pid_label.setText(str(os.getpid()))
+        self.url_label.setText(os.getenv("PYDM_ARCHIVER_URL"))
+
+    def configure_app(self):
+        """UI changes to be made to the PyDMApplication"""
+        app = QApplication.instance()
+        if not app.main_window:
+            return
+
+        # Hide navigation bar by default (can be shown in menu bar)
+        app.main_window.toggle_nav_bar(False)
+        app.main_window.ui.actionShow_Navigation_Bar.setChecked(False)
+
+        # Hide status bar by default (can be shown in menu bar)
+        app.main_window.toggle_status_bar(False)
+        app.main_window.ui.actionShow_Status_Bar.setChecked(False)
+
+    @staticmethod
+    def git_version():
+        """Get the current git tag for the project"""
+        project_directory = __file__.rsplit("/", 1)[0]
+        git_cmd = subprocess.run(
+            f"cd {project_directory} && git describe --tags", text=True, shell=True, capture_output=True
+        )
+        return git_cmd.stdout.strip()
+
+
+class BreakerLabel(QLabel):
+    breaker_font = QFont()
+    breaker_font.setBold(True)
+    breaker_font.setPointSize(12)
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.setText("|")
+        self.setFont(self.breaker_font)
+        self.setAlignment(Qt.AlignBottom)

--- a/trace/widgets/__init__.py
+++ b/trace/widgets/__init__.py
@@ -10,3 +10,4 @@ from .item_delegates import (
 )
 from .frozen_table_view import FrozenTableView
 from .data_insight_tool import DataInsightTool
+from .plot_settings import PlotSettingsModal

--- a/trace/widgets/plot_settings.py
+++ b/trace/widgets/plot_settings.py
@@ -23,14 +23,15 @@ class PlotSettingsModal(QWidget):
 
     def __init__(self, parent: QWidget, plot: PyDMArchiverTimePlot):
         super().__init__(parent)
-        self.setWindowFlag(Qt.WindowModal)
+        self.setWindowFlag(Qt.Popup)
 
         self.plot = plot
         main_layout = QVBoxLayout()
+        self.setLayout(main_layout)
 
         bold_font = QFont()
         bold_font.setBold(True)
-        bold_font.setPointSize(14)
+        bold_font.setPixelSize(14)
         title_label = QLabel("Plot Settings", self)
         title_label.setFont(bold_font)
         main_layout.addWidget(title_label)
@@ -52,7 +53,6 @@ class PlotSettingsModal(QWidget):
         legend_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
         legend_layout.addSpacerItem(legend_spacer)
         legend_checkbox = QCheckBox(self)
-        legend_checkbox.setChecked(True)
         legend_checkbox.stateChanged.connect(lambda check: self.plot.setShowLegend(bool(check)))
         legend_layout.addWidget(legend_checkbox)
         main_layout.addLayout(legend_layout)
@@ -69,7 +69,10 @@ class PlotSettingsModal(QWidget):
         as_interval_layout.addWidget(self.as_interval_spinbox)
         main_layout.addLayout(as_interval_layout)
 
+        bold_font = QFont()
+        bold_font.setBold(True)
         appearance_label = QLabel("Appearance", self)
+        appearance_label.setFont(bold_font)
         main_layout.addWidget(appearance_label)
 
         background_layout = QHBoxLayout()
@@ -90,7 +93,7 @@ class PlotSettingsModal(QWidget):
         x_axis_font_size_spinbox = QSpinBox(self)
         x_axis_font_size_spinbox.setValue(12)
         x_axis_font_size_spinbox.setSuffix(" pt")
-        x_axis_font_size_spinbox.valueChanged.connect(self.auto_scroll_interval_change.emit)
+        x_axis_font_size_spinbox.valueChanged.connect(self.set_x_axis_font_size)
         x_axis_font_size_layout.addWidget(x_axis_font_size_spinbox)
         main_layout.addLayout(x_axis_font_size_layout)
 
@@ -100,7 +103,6 @@ class PlotSettingsModal(QWidget):
         y_grid_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
         y_grid_layout.addSpacerItem(y_grid_spacer)
         self.y_grid_checkbox = QCheckBox(self)
-        self.y_grid_checkbox.setChecked(True)
         self.y_grid_checkbox.stateChanged.connect(self.show_y_grid)
         y_grid_layout.addWidget(self.y_grid_checkbox)
         main_layout.addLayout(y_grid_layout)
@@ -111,7 +113,6 @@ class PlotSettingsModal(QWidget):
         x_grid_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
         x_grid_layout.addSpacerItem(x_grid_spacer)
         self.x_grid_checkbox = QCheckBox(self)
-        self.x_grid_checkbox.setChecked(True)
         self.x_grid_checkbox.stateChanged.connect(self.show_x_grid)
         x_grid_layout.addWidget(self.x_grid_checkbox)
         main_layout.addLayout(x_grid_layout)
@@ -147,22 +148,29 @@ class PlotSettingsModal(QWidget):
         opacity /= 100
         return opacity
 
+    def show(self):
+        parent_pos = self.parent().rect().bottomRight()
+        global_pos = self.parent().mapToGlobal(parent_pos)
+        self.move(global_pos)
+        super().show()
+
     @Slot(int)
     def set_x_axis_font_size(self, size: int) -> None:
         font = QFont()
-        font.setPointSize(size)
+        font.setPixelSize(size)
         x_axis = self.plot.getAxis("bottom")
         x_axis.setStyle(tickFont=font)
 
-    @Slot(bool)
-    def show_y_grid(self, visible: bool):
-        self.plot.setShowYGrid(visible, self.gridline_opacity)
+    @Slot(int)
+    def show_y_grid(self, visible: int):
+        self.plot.setShowYGrid(bool(visible), self.gridline_opacity)
 
-    @Slot(bool)
-    def show_x_grid(self, visible: bool):
-        self.plot.setShowXGrid(visible, self.gridline_opacity)
+    @Slot(int)
+    def show_x_grid(self, visible: int):
+        self.plot.setShowXGrid(bool(visible), self.gridline_opacity)
 
     @Slot(int)
     def change_gridline_opacity(self, opacity: int):
+        opacity /= 100
         self.plot.setShowYGrid(self.y_grid_visible, opacity)
         self.plot.setShowXGrid(self.x_grid_visible, opacity)

--- a/trace/widgets/plot_settings.py
+++ b/trace/widgets/plot_settings.py
@@ -1,0 +1,168 @@
+from qtpy.QtGui import QFont
+from qtpy.QtCore import Qt, Slot, Signal
+from qtpy.QtWidgets import (
+    QLabel,
+    QSlider,
+    QWidget,
+    QSpinBox,
+    QCheckBox,
+    QLineEdit,
+    QHBoxLayout,
+    QSizePolicy,
+    QSpacerItem,
+    QVBoxLayout,
+)
+
+from pydm.widgets import PyDMArchiverTimePlot
+
+from widgets import ColorButton
+
+
+class PlotSettingsModal(QWidget):
+    auto_scroll_interval_change = Signal(int)
+
+    def __init__(self, parent: QWidget, plot: PyDMArchiverTimePlot):
+        super().__init__(parent)
+        self.setWindowFlag(Qt.WindowModal)
+
+        self.plot = plot
+        main_layout = QVBoxLayout()
+
+        bold_font = QFont()
+        bold_font.setBold(True)
+        bold_font.setPointSize(14)
+        title_label = QLabel("Plot Settings", self)
+        title_label.setFont(bold_font)
+        main_layout.addWidget(title_label)
+
+        plot_title_layout = QHBoxLayout()
+        plot_title_label = QLabel("Title", self)
+        plot_title_layout.addWidget(plot_title_label)
+        plot_title_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        plot_title_layout.addSpacerItem(plot_title_spacer)
+        plot_title_line_edit = QLineEdit()
+        plot_title_line_edit.setPlaceholderText("Enter Title")
+        plot_title_line_edit.textChanged.connect(self.plot.setPlotTitle)
+        plot_title_layout.addWidget(plot_title_line_edit)
+        main_layout.addLayout(plot_title_layout)
+
+        legend_layout = QHBoxLayout()
+        legend_label = QLabel("Legend", self)
+        legend_layout.addWidget(legend_label)
+        legend_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        legend_layout.addSpacerItem(legend_spacer)
+        legend_checkbox = QCheckBox(self)
+        legend_checkbox.setChecked(True)
+        legend_checkbox.stateChanged.connect(lambda check: self.plot.setShowLegend(bool(check)))
+        legend_layout.addWidget(legend_checkbox)
+        main_layout.addLayout(legend_layout)
+
+        as_interval_layout = QHBoxLayout()
+        as_interval_label = QLabel("Autoscroll Interval", self)
+        as_interval_layout.addWidget(as_interval_label)
+        as_interval_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        as_interval_layout.addSpacerItem(as_interval_spacer)
+        self.as_interval_spinbox = QSpinBox(self)
+        self.as_interval_spinbox.setValue(5)
+        self.as_interval_spinbox.setSuffix(" s")
+        self.as_interval_spinbox.valueChanged.connect(self.auto_scroll_interval_change.emit)
+        as_interval_layout.addWidget(self.as_interval_spinbox)
+        main_layout.addLayout(as_interval_layout)
+
+        appearance_label = QLabel("Appearance", self)
+        main_layout.addWidget(appearance_label)
+
+        background_layout = QHBoxLayout()
+        background_label = QLabel("  Background Color", self)
+        background_layout.addWidget(background_label)
+        as_interval_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        background_layout.addSpacerItem(as_interval_spacer)
+        background_button = ColorButton(parent=self, color="white")
+        background_button.color_changed.connect(self.plot.setBackgroundColor)
+        background_layout.addWidget(background_button)
+        main_layout.addLayout(background_layout)
+
+        x_axis_font_size_layout = QHBoxLayout()
+        x_axis_font_size_label = QLabel("  X Axis Font Size", self)
+        x_axis_font_size_layout.addWidget(x_axis_font_size_label)
+        x_axis_font_size_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        x_axis_font_size_layout.addSpacerItem(x_axis_font_size_spacer)
+        x_axis_font_size_spinbox = QSpinBox(self)
+        x_axis_font_size_spinbox.setValue(12)
+        x_axis_font_size_spinbox.setSuffix(" pt")
+        x_axis_font_size_spinbox.valueChanged.connect(self.auto_scroll_interval_change.emit)
+        x_axis_font_size_layout.addWidget(x_axis_font_size_spinbox)
+        main_layout.addLayout(x_axis_font_size_layout)
+
+        y_grid_layout = QHBoxLayout()
+        y_grid_label = QLabel("  Y Axis Gridline", self)
+        y_grid_layout.addWidget(y_grid_label)
+        y_grid_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        y_grid_layout.addSpacerItem(y_grid_spacer)
+        self.y_grid_checkbox = QCheckBox(self)
+        self.y_grid_checkbox.setChecked(True)
+        self.y_grid_checkbox.stateChanged.connect(self.show_y_grid)
+        y_grid_layout.addWidget(self.y_grid_checkbox)
+        main_layout.addLayout(y_grid_layout)
+
+        x_grid_layout = QHBoxLayout()
+        x_grid_label = QLabel("  X Axis Gridline", self)
+        x_grid_layout.addWidget(x_grid_label)
+        x_grid_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        x_grid_layout.addSpacerItem(x_grid_spacer)
+        self.x_grid_checkbox = QCheckBox(self)
+        self.x_grid_checkbox.setChecked(True)
+        self.x_grid_checkbox.stateChanged.connect(self.show_x_grid)
+        x_grid_layout.addWidget(self.x_grid_checkbox)
+        main_layout.addLayout(x_grid_layout)
+
+        grid_opacity_layout = QHBoxLayout()
+        grid_opacity_label = QLabel("  Gridline Opacity", self)
+        grid_opacity_layout.addWidget(grid_opacity_label)
+        grid_opacity_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        grid_opacity_layout.addSpacerItem(grid_opacity_spacer)
+        self.grid_opacity_slider = QSlider(self)
+        self.grid_opacity_slider.setOrientation(Qt.Horizontal)
+        self.grid_opacity_slider.setValue(50)
+        self.grid_opacity_slider.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.grid_opacity_slider.valueChanged.connect(self.change_gridline_opacity)
+        grid_opacity_layout.addWidget(self.grid_opacity_slider)
+        main_layout.addLayout(grid_opacity_layout)
+
+    @property
+    def auto_scroll_interval(self):
+        return self.as_interval_spinbox.value()
+
+    @property
+    def y_grid_visible(self):
+        return self.y_grid_checkbox.isChecked()
+
+    @property
+    def x_grid_visible(self):
+        return self.x_grid_checkbox.isChecked()
+
+    @property
+    def gridline_opacity(self):
+        opacity = self.grid_opacity_slider.value()
+        opacity /= 100
+        return opacity
+
+    @Slot(int)
+    def set_x_axis_font_size(self, size: int) -> None:
+        font = QFont()
+        font.setPointSize(size)
+        x_axis = self.plot.getAxis("bottom")
+        x_axis.setStyle(tickFont=font)
+
+    @Slot(bool)
+    def show_y_grid(self, visible: bool):
+        self.plot.setShowYGrid(visible, self.gridline_opacity)
+
+    @Slot(bool)
+    def show_x_grid(self, visible: bool):
+        self.plot.setShowXGrid(visible, self.gridline_opacity)
+
+    @Slot(int)
+    def change_gridline_opacity(self, opacity: int):
+        self.plot.setShowYGrid(self.y_grid_visible, opacity)
+        self.plot.setShowXGrid(self.x_grid_visible, opacity)


### PR DESCRIPTION
Creating a pure python display in `ui_redesign_test.py`. This PR creates a semi-functioning skeleton to replace trace's current design.

Add new PlotSettingsModal widget to open a popup window with all settings for the main plot of the application. This class should probably be renamed as it is not actually a modal.

The code should eventually replace `main.ui` & `main.py`

Related to #135 