### PR TITLE
ENH: Add Axis Settings Modal

### DIFF
--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 import qtawesome as qta
 from qtpy.QtGui import QFont
-from qtpy.QtCore import Qt, Slot, QSize
+from qtpy.QtCore import Qt, Slot, QSize, Signal
 from qtpy.QtWidgets import (
     QLabel,
     QWidget,
@@ -33,11 +33,18 @@ from widgets import DataInsightTool, PlotSettingsModal
 
 
 class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotConfigMixin):
+    gridline_opacity_change = Signal(int)
+
     def __init__(self, parent=None, args=None, macros=None) -> None:
         super(TraceDisplay, self).__init__(parent=parent, args=args, macros=macros, ui_filename=None)
         self.build_ui()
         self.configure_app()
         self.resize(1000, 600)
+
+    @property
+    def gridline_opacity(self) -> int:
+        """Get the current gridline opacity value from the plot settings"""
+        return self.plot_settings.gridline_opacity
 
     def minimumSizeHint(self):
         return QSize(700, 350)
@@ -93,6 +100,7 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         self.settings_button.setFlat(True)
 
         self.plot_settings = PlotSettingsModal(self.settings_button, self.plot)
+        self.plot_settings.grid_alpha_change.connect(self.gridline_opacity_change.emit)
         self.settings_button.clicked.connect(self.plot_settings.show)
 
         return plot_side_widget

--- a/trace/widgets/__init__.py
+++ b/trace/widgets/__init__.py
@@ -12,4 +12,5 @@ from .frozen_table_view import FrozenTableView
 from .data_insight_tool import DataInsightTool
 from .settings_components import SettingsTitle, SettingsRowItem, ComboBoxWrapper
 from .plot_settings import PlotSettingsModal
+from .axis_settings import AxisSettingsModal
 from .curve_settings import CurveSettingsModal

--- a/trace/widgets/axis_settings.py
+++ b/trace/widgets/axis_settings.py
@@ -2,7 +2,6 @@ from qtpy.QtGui import QFont
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import (
     QLabel,
-    QSlider,
     QWidget,
     QCheckBox,
     QComboBox,
@@ -66,28 +65,11 @@ class AxisSettingsModal(QWidget):
         grid_layout.addWidget(self.grid_checkbox)
         main_layout.addLayout(grid_layout)
 
-        grid_opacity_layout = QHBoxLayout()
-        grid_opacity_label = QLabel("Gridline Opacity", self)
-        grid_opacity_layout.addWidget(grid_opacity_label)
-        grid_opacity_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        grid_opacity_layout.addSpacerItem(grid_opacity_spacer)
-        self.grid_opacity_slider = QSlider(self)
-        self.grid_opacity_slider.setOrientation(Qt.Horizontal)
-        self.grid_opacity_slider.setValue(50)
-        self.grid_opacity_slider.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-        self.grid_opacity_slider.valueChanged.connect(self.change_gridline_opacity)
-        grid_opacity_layout.addWidget(self.grid_opacity_slider)
-        main_layout.addLayout(grid_opacity_layout)
+        self.parent().gridline_opacity_change.connect(self.change_gridline_opacity)
 
     @property
     def grid_visible(self):
         return self.grid_checkbox.isChecked()
-
-    @property
-    def gridline_opacity(self):
-        opacity = self.grid_opacity_slider.value()
-        opacity /= 100
-        return opacity
 
     def show(self):
         parent_pos = self.parent().rect().bottomRight()
@@ -108,17 +90,15 @@ class AxisSettingsModal(QWidget):
     def set_axis_log_mode(self, checked: int):
         self.axis.log_mode = bool(checked)
 
-    @Slot(bool)
     @Slot(int)
-    def show_grid(self, visible: bool | int):
+    def show_grid(self, visible: int):
         if not visible:
             self.axis.setGrid(False)
         else:
-            self.axis.setGrid(self.gridline_opacity)
+            self.axis.setGrid(self.parent().gridline_opacity)
 
     @Slot(int)
     def change_gridline_opacity(self, opacity: int):
         if not self.grid_visible:
             return
-        opacity /= 100
         self.axis.setGrid(opacity)

--- a/trace/widgets/axis_settings.py
+++ b/trace/widgets/axis_settings.py
@@ -1,18 +1,10 @@
-from qtpy.QtGui import QFont
 from qtpy.QtCore import Qt, Slot
-from qtpy.QtWidgets import (
-    QLabel,
-    QWidget,
-    QCheckBox,
-    QComboBox,
-    QHBoxLayout,
-    QSizePolicy,
-    QSpacerItem,
-    QVBoxLayout,
-)
+from qtpy.QtWidgets import QWidget, QCheckBox, QComboBox, QVBoxLayout
 
 from pydm.widgets import PyDMArchiverTimePlot
 from pydm.widgets.baseplot import BasePlotAxisItem
+
+from widgets import SettingsTitle, SettingsRowItem
 
 
 class AxisSettingsModal(QWidget):
@@ -25,45 +17,26 @@ class AxisSettingsModal(QWidget):
         main_layout = QVBoxLayout()
         self.setLayout(main_layout)
 
-        bold_font = QFont()
-        bold_font.setBold(True)
-        bold_font.setPixelSize(14)
-        title_label = QLabel("Axis Settings", self)
-        title_label.setFont(bold_font)
+        title_label = SettingsTitle(self, "Axis Settings", size=14)
         main_layout.addWidget(title_label)
 
-        orientation_layout = QHBoxLayout()
-        orientation_label = QLabel("Orientation", self)
-        orientation_layout.addWidget(orientation_label)
-        orientation_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        orientation_layout.addSpacerItem(orientation_spacer)
         orientation_combo = QComboBox(self)
         orientation_combo.addItems(["Left", "Right"])
         orientation_combo.currentTextChanged.connect(self.set_axis_orientation)
         orientation_combo.setCurrentText("Right" if self.axis.orientation == "right" else "Left")
-        orientation_layout.addWidget(orientation_combo)
-        main_layout.addLayout(orientation_layout)
+        orientation_row = SettingsRowItem(self, "Orientation", orientation_combo)
+        main_layout.addLayout(orientation_row)
 
-        log_layout = QHBoxLayout()
-        log_label = QLabel("Log Mode", self)
-        log_layout.addWidget(log_label)
-        log_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        log_layout.addSpacerItem(log_spacer)
         log_checkbox = QCheckBox(self)
         log_checkbox.setChecked(self.axis.log_mode)
         log_checkbox.stateChanged.connect(self.set_axis_log_mode)
-        log_layout.addWidget(log_checkbox)
-        main_layout.addLayout(log_layout)
+        log_mode_row = SettingsRowItem(self, "Log Mode", log_checkbox)
+        main_layout.addLayout(log_mode_row)
 
-        grid_layout = QHBoxLayout()
-        grid_label = QLabel("Gridline", self)
-        grid_layout.addWidget(grid_label)
-        grid_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        grid_layout.addSpacerItem(grid_spacer)
         self.grid_checkbox = QCheckBox(self)
         self.grid_checkbox.stateChanged.connect(self.show_grid)
-        grid_layout.addWidget(self.grid_checkbox)
-        main_layout.addLayout(grid_layout)
+        y_grid_row = SettingsRowItem(self, "Y Axis Gridline", self.grid_checkbox)
+        main_layout.addLayout(y_grid_row)
 
         self.parent().gridline_opacity_change.connect(self.change_gridline_opacity)
 

--- a/trace/widgets/axis_settings.py
+++ b/trace/widgets/axis_settings.py
@@ -70,6 +70,6 @@ class AxisSettingsModal(QWidget):
         if self.axis.isVisible():
             self.axis.show()
 
-    @Slot(bool)
-    def set_axis_log_mode(self, checked: bool):
-        self.axis.log_mode = checked
+    @Slot(int)
+    def set_axis_log_mode(self, checked: int):
+        self.axis.log_mode = bool(checked)

--- a/trace/widgets/axis_settings.py
+++ b/trace/widgets/axis_settings.py
@@ -2,6 +2,7 @@ from qtpy.QtGui import QFont
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import (
     QLabel,
+    QSlider,
     QWidget,
     QCheckBox,
     QComboBox,
@@ -55,6 +56,39 @@ class AxisSettingsModal(QWidget):
         log_layout.addWidget(log_checkbox)
         main_layout.addLayout(log_layout)
 
+        grid_layout = QHBoxLayout()
+        grid_label = QLabel("Gridline", self)
+        grid_layout.addWidget(grid_label)
+        grid_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        grid_layout.addSpacerItem(grid_spacer)
+        self.grid_checkbox = QCheckBox(self)
+        self.grid_checkbox.stateChanged.connect(self.show_grid)
+        grid_layout.addWidget(self.grid_checkbox)
+        main_layout.addLayout(grid_layout)
+
+        grid_opacity_layout = QHBoxLayout()
+        grid_opacity_label = QLabel("Gridline Opacity", self)
+        grid_opacity_layout.addWidget(grid_opacity_label)
+        grid_opacity_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        grid_opacity_layout.addSpacerItem(grid_opacity_spacer)
+        self.grid_opacity_slider = QSlider(self)
+        self.grid_opacity_slider.setOrientation(Qt.Horizontal)
+        self.grid_opacity_slider.setValue(50)
+        self.grid_opacity_slider.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.grid_opacity_slider.valueChanged.connect(self.change_gridline_opacity)
+        grid_opacity_layout.addWidget(self.grid_opacity_slider)
+        main_layout.addLayout(grid_opacity_layout)
+
+    @property
+    def grid_visible(self):
+        return self.grid_checkbox.isChecked()
+
+    @property
+    def gridline_opacity(self):
+        opacity = self.grid_opacity_slider.value()
+        opacity /= 100
+        return opacity
+
     def show(self):
         parent_pos = self.parent().rect().bottomRight()
         global_pos = self.parent().mapToGlobal(parent_pos)
@@ -73,3 +107,18 @@ class AxisSettingsModal(QWidget):
     @Slot(int)
     def set_axis_log_mode(self, checked: int):
         self.axis.log_mode = bool(checked)
+
+    @Slot(bool)
+    @Slot(int)
+    def show_grid(self, visible: bool | int):
+        if not visible:
+            self.axis.setGrid(False)
+        else:
+            self.axis.setGrid(self.gridline_opacity)
+
+    @Slot(int)
+    def change_gridline_opacity(self, opacity: int):
+        if not self.grid_visible:
+            return
+        opacity /= 100
+        self.axis.setGrid(opacity)

--- a/trace/widgets/axis_settings.py
+++ b/trace/widgets/axis_settings.py
@@ -1,0 +1,75 @@
+from qtpy.QtGui import QFont
+from qtpy.QtCore import Qt, Slot
+from qtpy.QtWidgets import (
+    QLabel,
+    QWidget,
+    QCheckBox,
+    QComboBox,
+    QHBoxLayout,
+    QSizePolicy,
+    QSpacerItem,
+    QVBoxLayout,
+)
+
+from pydm.widgets import PyDMArchiverTimePlot
+from pydm.widgets.baseplot import BasePlotAxisItem
+
+
+class AxisSettingsModal(QWidget):
+    def __init__(self, parent: QWidget, plot: PyDMArchiverTimePlot, axis: BasePlotAxisItem):
+        super().__init__(parent)
+        self.setWindowFlag(Qt.Popup)
+
+        self.plot = plot
+        self.axis = axis
+        main_layout = QVBoxLayout()
+        self.setLayout(main_layout)
+
+        bold_font = QFont()
+        bold_font.setBold(True)
+        bold_font.setPixelSize(14)
+        title_label = QLabel("Axis Settings", self)
+        title_label.setFont(bold_font)
+        main_layout.addWidget(title_label)
+
+        orientation_layout = QHBoxLayout()
+        orientation_label = QLabel("Orientation", self)
+        orientation_layout.addWidget(orientation_label)
+        orientation_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        orientation_layout.addSpacerItem(orientation_spacer)
+        orientation_combo = QComboBox(self)
+        orientation_combo.addItems(["Left", "Right"])
+        orientation_combo.currentTextChanged.connect(self.set_axis_orientation)
+        orientation_combo.setCurrentText("Right" if self.axis.orientation == "right" else "Left")
+        orientation_layout.addWidget(orientation_combo)
+        main_layout.addLayout(orientation_layout)
+
+        log_layout = QHBoxLayout()
+        log_label = QLabel("Log Mode", self)
+        log_layout.addWidget(log_label)
+        log_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        log_layout.addSpacerItem(log_spacer)
+        log_checkbox = QCheckBox(self)
+        log_checkbox.setChecked(self.axis.log_mode)
+        log_checkbox.stateChanged.connect(self.set_axis_log_mode)
+        log_layout.addWidget(log_checkbox)
+        main_layout.addLayout(log_layout)
+
+    def show(self):
+        parent_pos = self.parent().rect().bottomRight()
+        global_pos = self.parent().mapToGlobal(parent_pos)
+        self.move(global_pos)
+        super().show()
+
+    @Slot(str)
+    def set_axis_orientation(self, orientation: str):
+        if orientation not in ["Left", "Right"]:
+            return
+        self.axis.orientation = orientation.lower()
+        self.plot.plotItem.rebuildLayout()
+        if self.axis.isVisible():
+            self.axis.show()
+
+    @Slot(bool)
+    def set_axis_log_mode(self, checked: bool):
+        self.axis.log_mode = checked

--- a/trace/widgets/plot_settings.py
+++ b/trace/widgets/plot_settings.py
@@ -72,6 +72,7 @@ class PlotSettingsModal(QWidget):
         self.grid_opacity_slider.setOrientation(Qt.Horizontal)
         self.grid_opacity_slider.setMaximum(255)
         self.grid_opacity_slider.setValue(127)
+        self.grid_opacity_slider.setSingleStep(32)
         self.grid_opacity_slider.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.grid_opacity_slider.valueChanged.connect(self.change_gridline_opacity)
         grid_opacity_row = SettingsRowItem(self, "  Gridline Opacity", self.grid_opacity_slider)
@@ -110,6 +111,6 @@ class PlotSettingsModal(QWidget):
 
     @Slot(int)
     def change_gridline_opacity(self, opacity: int):
+        normalized_opacity = opacity / 255
+        self.plot.setShowXGrid(self.x_grid_visible, normalized_opacity)
         self.grid_alpha_change.emit(opacity)
-        opacity /= 255
-        self.plot.setShowXGrid(self.x_grid_visible, opacity)

--- a/trace/widgets/plot_settings.py
+++ b/trace/widgets/plot_settings.py
@@ -17,6 +17,7 @@ from widgets import ColorButton, SettingsTitle, SettingsRowItem
 
 class PlotSettingsModal(QWidget):
     auto_scroll_interval_change = Signal(int)
+    grid_alpha_change = Signal(int)
 
     def __init__(self, parent: QWidget, plot: PyDMArchiverTimePlot):
         super().__init__(parent)
@@ -62,11 +63,6 @@ class PlotSettingsModal(QWidget):
         x_axis_font_size_row = SettingsRowItem(self, "  X Axis Font Size", x_axis_font_size_spinbox)
         main_layout.addLayout(x_axis_font_size_row)
 
-        self.y_grid_checkbox = QCheckBox(self)
-        self.y_grid_checkbox.stateChanged.connect(self.show_y_grid)
-        y_grid_row = SettingsRowItem(self, "  Y Axis Gridline", self.y_grid_checkbox)
-        main_layout.addLayout(y_grid_row)
-
         self.x_grid_checkbox = QCheckBox(self)
         self.x_grid_checkbox.stateChanged.connect(self.show_x_grid)
         x_grid_row = SettingsRowItem(self, "  X Axis Gridline", self.x_grid_checkbox)
@@ -74,7 +70,8 @@ class PlotSettingsModal(QWidget):
 
         self.grid_opacity_slider = QSlider(self)
         self.grid_opacity_slider.setOrientation(Qt.Horizontal)
-        self.grid_opacity_slider.setValue(50)
+        self.grid_opacity_slider.setMaximum(255)
+        self.grid_opacity_slider.setValue(127)
         self.grid_opacity_slider.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.grid_opacity_slider.valueChanged.connect(self.change_gridline_opacity)
         grid_opacity_row = SettingsRowItem(self, "  Gridline Opacity", self.grid_opacity_slider)
@@ -85,17 +82,12 @@ class PlotSettingsModal(QWidget):
         return self.as_interval_spinbox.value()
 
     @property
-    def y_grid_visible(self):
-        return self.y_grid_checkbox.isChecked()
-
-    @property
     def x_grid_visible(self):
         return self.x_grid_checkbox.isChecked()
 
     @property
     def gridline_opacity(self):
         opacity = self.grid_opacity_slider.value()
-        opacity /= 100
         return opacity
 
     def show(self):
@@ -112,15 +104,12 @@ class PlotSettingsModal(QWidget):
         x_axis.setStyle(tickFont=font)
 
     @Slot(int)
-    def show_y_grid(self, visible: int):
-        self.plot.setShowYGrid(bool(visible), self.gridline_opacity)
-
-    @Slot(int)
     def show_x_grid(self, visible: int):
-        self.plot.setShowXGrid(bool(visible), self.gridline_opacity)
+        opacity = self.gridline_opacity / 255
+        self.plot.setShowXGrid(bool(visible), opacity)
 
     @Slot(int)
     def change_gridline_opacity(self, opacity: int):
-        opacity /= 100
-        self.plot.setShowYGrid(self.y_grid_visible, opacity)
+        self.grid_alpha_change.emit(opacity)
+        opacity /= 255
         self.plot.setShowXGrid(self.x_grid_visible, opacity)


### PR DESCRIPTION
Add a modal for controlling the settings of an axis. 

The modal class, `AxisSettingsModal`, takes in 3 arguments:
- parent: QWidget
  - This is the parent object of the modal. Should be whatever button opens the modal
- plot: PyDMArchiverTimePlot
  - This is the main plot of Trace
  - This is only used for redrawing the plot when the orientation changes. This should probably be done in PyDM instead of here
- axis: BasePlotAxisItem
  - The axis item that is controlled by the modal

The modal contains settings for:
- Changing the axis' orientation (left/right side)
- Enabling/disabling log mode for the axis
- Enabling/disabling gridlines on the axis
  - The opacity relies on the opacity slider from the `PlotSettingsModal`. This is done to keep the gridline opacity consistent across the plot