### PR TITLE
ENH: Add Curve/PV Settings Modal

### DIFF
--- a/trace/widgets/__init__.py
+++ b/trace/widgets/__init__.py
@@ -10,4 +10,6 @@ from .item_delegates import (
 )
 from .frozen_table_view import FrozenTableView
 from .data_insight_tool import DataInsightTool
+from .settings_components import SettingsTitle, SettingsRowItem, ComboBoxWrapper
 from .plot_settings import PlotSettingsModal
+from .curve_settings import CurveSettingsModal

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -80,8 +80,7 @@ class CurveSettingsModal(QWidget):
     def set_curve_color(self, color: QColor):
         self.curve.color = color
 
-    @Slot(str)
-    @Slot(None)
+    @Slot(object)
     def set_curve_type(self, curve_type: str | None):
         self.curve.stepMode = curve_type
 

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -24,7 +24,7 @@ class CurveSettingsModal(QWidget):
         name_row = SettingsRowItem(self, "Curve Name", name_edit)
         main_layout.addLayout(name_row)
 
-        color_button = ColorButton(self, curve.color_string)
+        color_button = ColorButton(parent=self, color=curve.color_string)
         color_button.color_changed.connect(self.set_curve_color)
         color_row = SettingsRowItem(self, "Color", color_button)
         main_layout.addLayout(color_row)

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -34,18 +34,18 @@ class CurveSettingsModal(QWidget):
 
         init_curve_type = "Step" if curve.stepMode in ["left", "right", "center"] else "Direct"
         type_combo = ComboBoxWrapper(self, {"Direct": None, "Step": "right"}, init_curve_type)
-        type_combo.clean_text_changed.connect(self.set_curve_type)
+        type_combo.text_changed.connect(self.set_curve_type)
         type_row = SettingsRowItem(self, "  Type", type_combo)
         main_layout.addLayout(type_row)
 
         style_combo = ComboBoxWrapper(self, TimePlotCurveItem.lines, curve.lineStyle)
-        style_combo.clean_text_changed.connect(self.set_curve_style)
+        style_combo.text_changed.connect(self.set_curve_style)
         style_row = SettingsRowItem(self, "  Style", style_combo)
         main_layout.addLayout(style_row)
 
         width_options = {f"{i}px": i for i in range(1, 6)}
         width_combo = ComboBoxWrapper(self, width_options, curve.lineWidth)
-        width_combo.clean_text_changed.connect(self.set_curve_width)
+        width_combo.text_changed.connect(self.set_curve_width)
         width_row = SettingsRowItem(self, "  Width", width_combo)
         main_layout.addLayout(width_row)
 
@@ -53,13 +53,13 @@ class CurveSettingsModal(QWidget):
         main_layout.addWidget(symbol_title_label)
 
         shape_combo = ComboBoxWrapper(self, TimePlotCurveItem.symbols, curve.symbol)
-        shape_combo.clean_text_changed.connect(self.set_symbol_shape)
+        shape_combo.text_changed.connect(self.set_symbol_shape)
         shape_row = SettingsRowItem(self, "  Shape", shape_combo)
         main_layout.addLayout(shape_row)
 
         size_options = {f"{i}px": i for i in range(5, 26, 5)}
         size_combo = ComboBoxWrapper(self, size_options, curve.symbolSize)
-        size_combo.clean_text_changed.connect(self.set_symbol_size)
+        size_combo.text_changed.connect(self.set_symbol_size)
         size_row = SettingsRowItem(self, "  Size", size_combo)
         main_layout.addLayout(size_row)
 
@@ -84,18 +84,18 @@ class CurveSettingsModal(QWidget):
     def set_curve_type(self, curve_type: str | None):
         self.curve.stepMode = curve_type
 
-    @Slot(int)
+    @Slot(object)
     def set_curve_style(self, style: int):
         self.curve.lineStyle = style
 
-    @Slot(int)
+    @Slot(object)
     def set_curve_width(self, width: int):
         self.curve.lineWidth = width
 
-    @Slot(str)
+    @Slot(object)
     def set_symbol_shape(self, shape: str):
         self.curve.symbol = shape
 
-    @Slot(int)
+    @Slot(object)
     def set_symbol_size(self, size: int):
         self.curve.symbolSize = size

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -63,6 +63,12 @@ class CurveSettingsModal(QWidget):
         size_row = SettingsRowItem(self, "  Size", size_combo)
         main_layout.addLayout(size_row)
 
+    def show(self):
+        parent_pos = self.parent().rect().bottomRight()
+        global_pos = self.parent().mapToGlobal(parent_pos)
+        self.move(global_pos)
+        super().show()
+
     @Slot()
     def set_curve_name(self):
         sender = self.sender()

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -1,0 +1,102 @@
+from qtpy.QtGui import QColor
+from qtpy.QtCore import Qt, Slot
+from qtpy.QtWidgets import QWidget, QLineEdit, QVBoxLayout
+
+from pydm.widgets.archiver_time_plot import TimePlotCurveItem
+
+from widgets import ColorButton, SettingsTitle, ComboBoxWrapper, SettingsRowItem
+
+
+class CurveSettingsModal(QWidget):
+    def __init__(self, parent: QWidget, curve: TimePlotCurveItem):
+        super().__init__(parent)
+        self.setWindowFlag(Qt.Popup)
+
+        self.curve = curve
+        main_layout = QVBoxLayout()
+        self.setLayout(main_layout)
+
+        title_label = SettingsTitle(self, "Curve Settings", size=14)
+        main_layout.addWidget(title_label)
+
+        name_edit = QLineEdit(curve.name(), self)
+        name_edit.editingFinished.connect(self.set_curve_name)
+        name_row = SettingsRowItem(self, "Curve Name", name_edit)
+        main_layout.addLayout(name_row)
+
+        color_button = ColorButton(self, curve.color_string)
+        color_button.color_changed.connect(self.set_curve_color)
+        color_row = SettingsRowItem(self, "Color", color_button)
+        main_layout.addLayout(color_row)
+
+        line_title_label = SettingsTitle(self, "Line")
+        main_layout.addWidget(line_title_label)
+
+        init_curve_type = "Step" if curve.stepMode in ["left", "right", "center"] else "Direct"
+        type_combo = ComboBoxWrapper(self, {"Direct": None, "Step": "right"}, init_curve_type)
+        type_combo.clean_text_changed.connect(self.set_curve_type)
+        type_row = SettingsRowItem(self, "  Type", type_combo)
+        main_layout.addLayout(type_row)
+
+        style_combo = ComboBoxWrapper(self, TimePlotCurveItem.lines, curve.lineStyle)
+        style_combo.clean_text_changed.connect(self.set_curve_style)
+        style_row = SettingsRowItem(self, "  Style", style_combo)
+        main_layout.addLayout(style_row)
+
+        width_options = {f"{i}px": i for i in range(1, 6)}
+        width_combo = ComboBoxWrapper(self, width_options, curve.lineWidth)
+        width_combo.clean_text_changed.connect(self.set_curve_width)
+        width_row = SettingsRowItem(self, "  Width", width_combo)
+        main_layout.addLayout(width_row)
+
+        symbol_title_label = SettingsTitle(self, "Symbol")
+        main_layout.addWidget(symbol_title_label)
+
+        shape_combo = ComboBoxWrapper(self, TimePlotCurveItem.symbols, curve.symbol)
+        shape_combo.clean_text_changed.connect(self.set_symbol_shape)
+        shape_row = SettingsRowItem(self, "  Shape", shape_combo)
+        main_layout.addLayout(shape_row)
+
+        size_options = {f"{i}px": i for i in range(5, 26, 5)}
+        size_combo = ComboBoxWrapper(self, size_options, curve.symbolSize)
+        size_combo.clean_text_changed.connect(self.set_symbol_size)
+        size_row = SettingsRowItem(self, "  Size", size_combo)
+        main_layout.addLayout(size_row)
+
+    @Slot()
+    def set_curve_name(self):
+        sender = self.sender()
+        name = sender.text()
+
+        if not name:
+            sender.blockSignals(True)
+            sender.setText(self.curve.name())
+            sender.blockSignals(False)
+        elif name != self.curve.name():
+            self.curve.setName(name)
+            self.curve.update()
+
+    @Slot(QColor)
+    def set_curve_color(self, color: QColor):
+        self.curve.color = color
+
+    @Slot(str)
+    @Slot(None)
+    def set_curve_type(self, curve_type: str | None):
+        self.curve.stepMode = curve_type
+
+    @Slot(int)
+    def set_curve_style(self, style: int):
+        self.curve.lineStyle = style
+
+    @Slot(int)
+    def set_curve_width(self, width: int):
+        self.curve.lineWidth = width
+
+    @Slot(str)
+    def set_symbol_shape(self, shape: str):
+        self.curve.symbol = shape
+
+    @Slot(int)
+    def set_symbol_size(self, size: int):
+        self.curve.symbolSize = size

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -2,16 +2,17 @@ from qtpy.QtGui import QColor
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QWidget, QLineEdit, QVBoxLayout
 
-from pydm.widgets.archiver_time_plot import TimePlotCurveItem
+from pydm.widgets.archiver_time_plot import TimePlotCurveItem, PyDMArchiverTimePlot
 
 from widgets import ColorButton, SettingsTitle, ComboBoxWrapper, SettingsRowItem
 
 
 class CurveSettingsModal(QWidget):
-    def __init__(self, parent: QWidget, curve: TimePlotCurveItem):
+    def __init__(self, parent: QWidget, plot: PyDMArchiverTimePlot, curve: TimePlotCurveItem):
         super().__init__(parent)
         self.setWindowFlag(Qt.Popup)
 
+        self.legend = plot._legend
         self.curve = curve
         main_layout = QVBoxLayout()
         self.setLayout(main_layout)
@@ -79,8 +80,11 @@ class CurveSettingsModal(QWidget):
             sender.setText(self.curve.name())
             sender.blockSignals(False)
         elif name != self.curve.name():
-            self.curve.setName(name)
-            self.curve.update()
+            legend_label = self.legend.getLabel(self.curve)
+            legend_label.setText(name)
+
+            x, y = self.curve.getData()
+            self.curve.setData(name=name, x=x, y=y)
 
     @Slot(QColor)
     def set_curve_color(self, color: QColor):

--- a/trace/widgets/plot_settings.py
+++ b/trace/widgets/plot_settings.py
@@ -1,21 +1,18 @@
 from qtpy.QtGui import QFont
 from qtpy.QtCore import Qt, Slot, Signal
 from qtpy.QtWidgets import (
-    QLabel,
     QSlider,
     QWidget,
     QSpinBox,
     QCheckBox,
     QLineEdit,
-    QHBoxLayout,
     QSizePolicy,
-    QSpacerItem,
     QVBoxLayout,
 )
 
 from pydm.widgets import PyDMArchiverTimePlot
 
-from widgets import ColorButton
+from widgets import ColorButton, SettingsTitle, SettingsRowItem
 
 
 class PlotSettingsModal(QWidget):
@@ -29,106 +26,59 @@ class PlotSettingsModal(QWidget):
         main_layout = QVBoxLayout()
         self.setLayout(main_layout)
 
-        bold_font = QFont()
-        bold_font.setBold(True)
-        bold_font.setPixelSize(14)
-        title_label = QLabel("Plot Settings", self)
-        title_label.setFont(bold_font)
+        title_label = SettingsTitle(self, "Plot Settings", size=14)
         main_layout.addWidget(title_label)
 
-        plot_title_layout = QHBoxLayout()
-        plot_title_label = QLabel("Title", self)
-        plot_title_layout.addWidget(plot_title_label)
-        plot_title_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        plot_title_layout.addSpacerItem(plot_title_spacer)
         plot_title_line_edit = QLineEdit()
         plot_title_line_edit.setPlaceholderText("Enter Title")
         plot_title_line_edit.textChanged.connect(self.plot.setPlotTitle)
-        plot_title_layout.addWidget(plot_title_line_edit)
-        main_layout.addLayout(plot_title_layout)
+        plot_title_row = SettingsRowItem(self, "Title", plot_title_line_edit)
+        main_layout.addLayout(plot_title_row)
 
-        legend_layout = QHBoxLayout()
-        legend_label = QLabel("Legend", self)
-        legend_layout.addWidget(legend_label)
-        legend_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        legend_layout.addSpacerItem(legend_spacer)
         legend_checkbox = QCheckBox(self)
         legend_checkbox.stateChanged.connect(lambda check: self.plot.setShowLegend(bool(check)))
-        legend_layout.addWidget(legend_checkbox)
-        main_layout.addLayout(legend_layout)
+        legend_row = SettingsRowItem(self, "Show Legend", legend_checkbox)
+        main_layout.addLayout(legend_row)
 
-        as_interval_layout = QHBoxLayout()
-        as_interval_label = QLabel("Autoscroll Interval", self)
-        as_interval_layout.addWidget(as_interval_label)
-        as_interval_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        as_interval_layout.addSpacerItem(as_interval_spacer)
         self.as_interval_spinbox = QSpinBox(self)
         self.as_interval_spinbox.setValue(5)
         self.as_interval_spinbox.setSuffix(" s")
         self.as_interval_spinbox.valueChanged.connect(self.auto_scroll_interval_change.emit)
-        as_interval_layout.addWidget(self.as_interval_spinbox)
-        main_layout.addLayout(as_interval_layout)
+        as_interval_row = SettingsRowItem(self, "Autoscroll Interval", self.as_interval_spinbox)
+        main_layout.addLayout(as_interval_row)
 
-        bold_font = QFont()
-        bold_font.setBold(True)
-        appearance_label = QLabel("Appearance", self)
-        appearance_label.setFont(bold_font)
+        appearance_label = SettingsTitle(self, "Appearance")
         main_layout.addWidget(appearance_label)
 
-        background_layout = QHBoxLayout()
-        background_label = QLabel("  Background Color", self)
-        background_layout.addWidget(background_label)
-        as_interval_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        background_layout.addSpacerItem(as_interval_spacer)
         background_button = ColorButton(parent=self, color="white")
         background_button.color_changed.connect(self.plot.setBackgroundColor)
-        background_layout.addWidget(background_button)
-        main_layout.addLayout(background_layout)
+        background_row = SettingsRowItem(self, "  Background Color", background_button)
+        main_layout.addLayout(background_row)
 
-        x_axis_font_size_layout = QHBoxLayout()
-        x_axis_font_size_label = QLabel("  X Axis Font Size", self)
-        x_axis_font_size_layout.addWidget(x_axis_font_size_label)
-        x_axis_font_size_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        x_axis_font_size_layout.addSpacerItem(x_axis_font_size_spacer)
         x_axis_font_size_spinbox = QSpinBox(self)
         x_axis_font_size_spinbox.setValue(12)
         x_axis_font_size_spinbox.setSuffix(" pt")
         x_axis_font_size_spinbox.valueChanged.connect(self.set_x_axis_font_size)
-        x_axis_font_size_layout.addWidget(x_axis_font_size_spinbox)
-        main_layout.addLayout(x_axis_font_size_layout)
+        x_axis_font_size_row = SettingsRowItem(self, "  X Axis Font Size", x_axis_font_size_spinbox)
+        main_layout.addLayout(x_axis_font_size_row)
 
-        y_grid_layout = QHBoxLayout()
-        y_grid_label = QLabel("  Y Axis Gridline", self)
-        y_grid_layout.addWidget(y_grid_label)
-        y_grid_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        y_grid_layout.addSpacerItem(y_grid_spacer)
         self.y_grid_checkbox = QCheckBox(self)
         self.y_grid_checkbox.stateChanged.connect(self.show_y_grid)
-        y_grid_layout.addWidget(self.y_grid_checkbox)
-        main_layout.addLayout(y_grid_layout)
+        y_grid_row = SettingsRowItem(self, "  Y Axis Gridline", self.y_grid_checkbox)
+        main_layout.addLayout(y_grid_row)
 
-        x_grid_layout = QHBoxLayout()
-        x_grid_label = QLabel("  X Axis Gridline", self)
-        x_grid_layout.addWidget(x_grid_label)
-        x_grid_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        x_grid_layout.addSpacerItem(x_grid_spacer)
         self.x_grid_checkbox = QCheckBox(self)
         self.x_grid_checkbox.stateChanged.connect(self.show_x_grid)
-        x_grid_layout.addWidget(self.x_grid_checkbox)
-        main_layout.addLayout(x_grid_layout)
+        x_grid_row = SettingsRowItem(self, "  X Axis Gridline", self.x_grid_checkbox)
+        main_layout.addLayout(x_grid_row)
 
-        grid_opacity_layout = QHBoxLayout()
-        grid_opacity_label = QLabel("  Gridline Opacity", self)
-        grid_opacity_layout.addWidget(grid_opacity_label)
-        grid_opacity_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
-        grid_opacity_layout.addSpacerItem(grid_opacity_spacer)
         self.grid_opacity_slider = QSlider(self)
         self.grid_opacity_slider.setOrientation(Qt.Horizontal)
         self.grid_opacity_slider.setValue(50)
         self.grid_opacity_slider.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.grid_opacity_slider.valueChanged.connect(self.change_gridline_opacity)
-        grid_opacity_layout.addWidget(self.grid_opacity_slider)
-        main_layout.addLayout(grid_opacity_layout)
+        grid_opacity_row = SettingsRowItem(self, "  Gridline Opacity", self.grid_opacity_slider)
+        main_layout.addLayout(grid_opacity_row)
 
     @property
     def auto_scroll_interval(self):

--- a/trace/widgets/settings_components.py
+++ b/trace/widgets/settings_components.py
@@ -21,9 +21,9 @@ class SettingsTitle(QLabel):
 
 
 class SettingsRowItem(QHBoxLayout):
-    def __init__(self, parent: QWidget, label_txt: str, widget: QWidget):
-        super().__init__(parent)
-        label = QLabel(label_txt, self)
+    def __init__(self, label_parent: QWidget, label_txt: str, widget: QWidget):
+        super().__init__()
+        label = QLabel(label_txt, label_parent)
         self.addWidget(label)
 
         spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)

--- a/trace/widgets/settings_components.py
+++ b/trace/widgets/settings_components.py
@@ -37,7 +37,7 @@ class ComboBoxWrapper(QComboBox):
 
     def __init__(self, parent: QWidget, data_source: list | tuple | dict, init_value: int | str = None):
         super().__init__(parent)
-        if isinstance(data_source, list, tuple):
+        if isinstance(data_source, (list, tuple)):
             data_source = {v: v for v in data_source}
         self.data_source = data_source
         self.addItems(self.data_source.keys())

--- a/trace/widgets/settings_components.py
+++ b/trace/widgets/settings_components.py
@@ -1,0 +1,59 @@
+from qtpy.QtGui import QFont
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import (
+    QLabel,
+    QWidget,
+    QComboBox,
+    QHBoxLayout,
+    QSizePolicy,
+    QSpacerItem,
+)
+
+
+class SettingsTitle(QLabel):
+    def __init__(self, parent: QWidget, text: str, size: int = None):
+        super().__init__(text=text, parent=parent)
+        bold_font = QFont()
+        bold_font.setBold(True)
+        if size is not None:
+            bold_font.setPixelSize(size)
+        self.setFont(bold_font)
+
+
+class SettingsRowItem(QHBoxLayout):
+    def __init__(self, parent: QWidget, label_txt: str, widget: QWidget):
+        super().__init__(parent)
+        label = QLabel(label_txt, self)
+        self.addWidget(label)
+
+        spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.addSpacerItem(spacer)
+
+        self.addWidget(widget)
+
+
+class ComboBoxWrapper(QComboBox):
+    text_changed = Signal(object)
+
+    def __init__(self, parent: QWidget, data_source: list | tuple | dict, init_value: int | str = None):
+        super().__init__(parent)
+        if isinstance(data_source, list, tuple):
+            data_source = {v: v for v in data_source}
+        self.data_source = data_source
+        self.addItems(self.data_source.keys())
+
+        if init_value is not None:
+            if str(init_value) in self.data_source:
+                self.setCurrentText(str(init_value))
+            else:
+                value_ind = list(self.data_source.values()).index(init_value)
+                self.setCurrentIndex(value_ind)
+
+        self.currentTextChanged.connect(self.clean_text_changed)
+
+    def clean_text_changed(self, inc_text: str):
+        outgoing_text = inc_text
+        if inc_text in self.data_source:
+            outgoing_text = self.data_source[inc_text]
+
+        self.text_changed.emit(outgoing_text)


### PR DESCRIPTION
### `CurveSettingsModal`
Create a settings modal for controlling the look of individual curves. The modal will open to the bottom right of its parent widget, similar to the modal in #137.

#### The modal class, `CurveSettingsModal`, takes in 3 arguments:
- parent: QWidget
  - This is the parent object of the modal. Should be whatever button opens the modal
- plot: PyDMArchiverTimePlot
  - This is the main plot of Trace
  - This is only used for redrawing the plot when the orientation changes. This should probably be done in PyDM instead of here
- curve: TimePlotCurveItem
  - The curve item that is controlled by the modal

#### The modal contains settings for:
- Setting the curve's name (label in the legend)
- Color
- Appearance
  - Line type (step or direct)
  - Style (solid, dotted, dashed, etc.)
  - Width
- Symbol
  - Shape (circle, star, none, etc.)
  - Size

#### Settings components:
Also created a file containing reused components of the settings modals. Changed PlotSettingsModal to use common settings components.

### Images of Modal
![Screenshot 2025-04-21 at 15 32 45](https://github.com/user-attachments/assets/a140a92d-ecd2-446f-947b-eaa3a6afe91e)
![Screenshot 2025-04-21 at 15 33 41](https://github.com/user-attachments/assets/afbbbd1b-1d88-43ba-80c5-f3169027049a)
