### PR TITLE
ENH: Use qtawesome icon for plot settings button

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ pydm
 pandas
 pytest
 pytest-qt
+qtawesome
 mkdocs
 mkdocs-material
 mkdocstrings

--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -3,13 +3,12 @@ import subprocess
 from socket import gethostname
 from getpass import getuser
 from datetime import datetime
-import qtawesome as qta
 
+import qtawesome as qta
 from qtpy.QtGui import QFont
 from qtpy.QtCore import Qt, Slot, QSize
 from qtpy.QtWidgets import (
     QLabel,
-    QStyle,
     QWidget,
     QLineEdit,
     QSplitter,

--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -3,6 +3,7 @@ import subprocess
 from socket import gethostname
 from getpass import getuser
 from datetime import datetime
+import qtawesome as qta
 
 from qtpy.QtGui import QFont
 from qtpy.QtCore import Qt, Slot, QSize
@@ -88,9 +89,9 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         multi_axis_plot.sigXRangeChangedManually.connect(self.disable_auto_scroll_button.click)
         plot_side_layout.addWidget(self.plot)
 
-        settings_icon = self.style().standardIcon(QStyle.SP_MessageBoxWarning)  # TODO: replace temporary icon
         self.settings_button = QPushButton(self.plot)
-        self.settings_button.setIcon(settings_icon)
+        self.settings_button.setIcon(qta.icon("msc.settings-gear"))
+        self.settings_button.setFlat(True)
 
         self.plot_settings = PlotSettingsModal(self.settings_button, self.plot)
         self.settings_button.clicked.connect(self.plot_settings.show)


### PR DESCRIPTION
Replaces the placeholder icon for the plot settings button with a settings cog icon.
Credit to @shilorigins for finding the qtawesome icon set.
![image](https://github.com/user-attachments/assets/c70a54db-8f48-48fd-8eb6-ea02c779534b)
