### PR TITLE
ENH: Adding X-Range Controls to Plot Settings

### DIFF
--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -31,6 +31,8 @@ from config import logger, datetime_pv
 from mixins import FileIOMixin, AxisTableMixin, PlotConfigMixin, TracesTableMixin
 from widgets import DataInsightTool, PlotSettingsModal
 
+DISABLE_AUTO_SCROLL = -2  # Using -2 as invalid since QButtonGroups use -1 as invalid
+
 
 class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotConfigMixin):
     gridline_opacity_change = Signal(int)
@@ -40,6 +42,10 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         self.build_ui()
         self.configure_app()
         self.resize(1000, 600)
+
+        # Set plot's timerange after the UI is built
+        default_button = self.timespan_buttons.button(3600)
+        default_button.setChecked(True)
 
     @property
     def gridline_opacity(self) -> int:
@@ -100,6 +106,7 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         self.settings_button.setFlat(True)
 
         self.plot_settings = PlotSettingsModal(self.settings_button, self.plot)
+        self.plot_settings.auto_scroll_interval_change.connect(self.set_auto_scroll_interval)
         self.plot_settings.grid_alpha_change.connect(self.gridline_opacity_change.emit)
         self.settings_button.clicked.connect(self.plot_settings.show)
 
@@ -139,7 +146,7 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
             ("1d", 86400),
             ("1w", 604800),
             ("1M", 2628300),
-            ("Disable AutoScroll", -2),
+            ("Disable AutoScroll", DISABLE_AUTO_SCROLL),
         )
 
         for text, id in timespan_button_data:
@@ -149,10 +156,7 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
             timespan_button_layout.addWidget(timespan_button)
             self.timespan_buttons.addButton(timespan_button, id)
 
-        default_button = self.timespan_buttons.button(3600)
-        default_button.setChecked(True)
-
-        self.disable_auto_scroll_button = self.timespan_buttons.button(-2)
+        self.disable_auto_scroll_button = self.timespan_buttons.button(DISABLE_AUTO_SCROLL)
         self.disable_auto_scroll_button.hide()
 
         self.timespan_buttons.buttonToggled.connect(self.set_plot_timerange)
@@ -278,12 +282,20 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         """
         timespan = self.timespan_buttons.checkedId()
 
-        enable_scroll = timespan != -2
+        enable_scroll = timespan != DISABLE_AUTO_SCROLL
         if enable_scroll:
             logger.debug(f"Enabling plot autoscroll for {timespan}s")
         else:
             logger.debug("Disabling plot autoscroll, using mouse controls")
         self.autoScroll(enable=enable_scroll, timespan=timespan)
+
+    @Slot(int)
+    def set_auto_scroll_interval(self, inteval: int) -> None:
+        """Set the auto scroll interval for the plot"""
+        timespan = self.timespan_buttons.checkedId()
+        enable_scroll = timespan != DISABLE_AUTO_SCROLL
+
+        self.plot.setAutoScroll(enable_scroll, timespan, refresh_rate=inteval)
 
     @Slot(bool)
     @Slot(bool, int)
@@ -293,8 +305,8 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
             if timespan < 0:
                 return
 
-        refresh_rate = self.plot_settings.auto_scroll_interval
-        self.plot.setAutoScroll(enable, timespan, refresh_rate=refresh_rate)
+        refresh_interval = self.plot_settings.auto_scroll_interval
+        self.plot.setAutoScroll(enable, timespan, refresh_rate=refresh_interval)
 
     @staticmethod
     def git_version():

--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -108,6 +108,7 @@ class TraceDisplay(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, PlotC
         self.plot_settings = PlotSettingsModal(self.settings_button, self.plot)
         self.plot_settings.auto_scroll_interval_change.connect(self.set_auto_scroll_interval)
         self.plot_settings.grid_alpha_change.connect(self.gridline_opacity_change.emit)
+        self.plot_settings.disable_autoscroll.connect(self.disable_auto_scroll_button.click)
         self.settings_button.clicked.connect(self.plot_settings.show)
 
         return plot_side_widget

--- a/trace/widgets/plot_settings.py
+++ b/trace/widgets/plot_settings.py
@@ -27,7 +27,7 @@ class PlotSettingsModal(QWidget):
 
     def __init__(self, parent: QWidget, plot: PyDMArchiverTimePlot):
         super().__init__(parent)
-        self.setWindowFlag(Qt.Tool)
+        self.setWindowFlag(Qt.Popup)
 
         self.plot = plot
         main_layout = QVBoxLayout()


### PR DESCRIPTION

## Main Enhancement
### Adding X-Axis controls to the `PlotSettingsModal`
- Mimics PR: #17
- Added 2 new rows labeled "Start Time" and "End Time" each with a `QDateTimeEdit` to `PlotSettingsModal`
  - When a new date is set for either auto-scrolling will be turned off and the plot's x-axis will be changed
  - If the x-axis changes, the values in the `QDateTimeEdit`s also change to reflect the updated x-axis range

## Additional Fixes
### Fix Auto-Scroll Interval
- `TraceDisplay` did not have a slot connected to the signal `PlotSettingsModal.auto_scroll_interval_change`
- Now it correctly adjusts the interval of the plot's auto scrolling feature by using the slot `TraceDisplay.set_auto_scroll_interval`

### Constant for Disable Auto Scroll Button
- Set a constant value for the value of `TraceDisplay.disable_auto_scroll_button`
- Reasons for doing this:
  - It is set to a non-common value (-2) because -1 is a special value for `QButtonGroup`s
  - The value is referenced in a couple places and the non-common value (-2) could cause confusion
