### PR TITLE
BUG: don't iterate using indices in AxisItem.close

### DIFF
--- a/trace/widgets/control_panel.py
+++ b/trace/widgets/control_panel.py
@@ -213,10 +213,10 @@ class AxisItem(QtWidgets.QWidget):
         self.settings_modal.show()
 
     def close(self) -> bool:
+        while self.layout().count() > 1:
+            self.layout().itemAt(1).widget().close()
         self.source.sigYRangeChanged.disconnect(self.handle_range_change)
         self.source.linkedView().sigRangeChangedManually.disconnect(self.disable_auto_range)
-        for i in range(1, self.layout().count()):
-            self.layout().itemAt(i).widget().close()
         index = self.parent().plot._axes.index(self.source)
         self.parent().plot.removeAxisAtIndex(index)
         self.setParent(None)


### PR DESCRIPTION
Using indicing to iterate was causing half of the indices to become invalid, causing errors.

Disconnecting the signals after closing all children is also important; this way, any error encountered while closing children doesn't disconnect the signals, so the axis continues working and a second call to disconnect doesn't error.

Closes #144