### PR TITLE
ENH: Add DataInsightTool to UI Redesign

### DIFF
--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -64,6 +64,7 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         plot_side_widget = self.build_plot_side(self)
         control_panel = ControlPanel()
         control_panel.plot = self.plot
+        control_panel.curve_list_changed.connect(self.data_insight_tool.update_pv_select_box)
 
         # Create main splitter
         main_splitter = QSplitter(self)

--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -117,15 +117,20 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         tool_layout = QHBoxLayout()
         tool_layout.setContentsMargins(0, 0, 0, 0)
         toolbar_widget.setLayout(tool_layout)
+
         save_image_button = QPushButton("Save Image", toolbar_widget)
         save_image_button.clicked.connect(self.save_plot_image)
         tool_layout.addWidget(save_image_button)
+
         tool_spacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
         tool_layout.addSpacerItem(tool_spacer)
+
         timespan_buttons = self.build_timespan_buttons(toolbar_widget)
         tool_layout.addWidget(timespan_buttons)
+
+        self.data_insight_tool = DataInsightTool(self, self.plot)
         data_insight_tool_button = QPushButton("Data Insight Tool", toolbar_widget)
-        data_insight_tool_button.clicked.connect(self.open_data_insight_tool)
+        data_insight_tool_button.clicked.connect(self.data_insight_tool.show)
         tool_layout.addWidget(data_insight_tool_button)
 
         return toolbar_widget
@@ -242,12 +247,6 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
             self.plot.requestDataFromArchiver()
         else:
             logger.info("Archive fetch is already queued")
-
-    @Slot()
-    def open_data_insight_tool(self):
-        """Create a new instance of the Data Insight Tool"""
-        dit = DataInsightTool(self, self.curves_model, self.plot)
-        dit.show()
 
     @Slot()
     def set_plot_timerange(self) -> None:

--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -99,6 +99,8 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         multi_axis_plot.sigXRangeChangedManually.connect(self.disable_auto_scroll_button.click)
         plot_side_layout.addWidget(self.plot)
 
+        self.data_insight_tool.plot = self.plot
+
         self.settings_button = QPushButton(self.plot)
         self.settings_button.setIcon(qta.icon("msc.settings-gear"))
         self.settings_button.setFlat(True)
@@ -128,7 +130,7 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         timespan_buttons = self.build_timespan_buttons(toolbar_widget)
         tool_layout.addWidget(timespan_buttons)
 
-        self.data_insight_tool = DataInsightTool(self, self.plot)
+        self.data_insight_tool = DataInsightTool(self)
         data_insight_tool_button = QPushButton("Data Insight Tool", toolbar_widget)
         data_insight_tool_button.clicked.connect(self.data_insight_tool.show)
         tool_layout.addWidget(data_insight_tool_button)

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -295,13 +295,11 @@ class DataInsightTool(QWidget):
     to export the raw data from this tool.
     """
 
-    def __init__(self, parent: QObject, plot: PyDMArchiverTimePlot) -> None:
+    def __init__(self, parent: QObject, plot: PyDMArchiverTimePlot = None) -> None:
         super().__init__(parent=parent)
         self.setWindowFlag(Qt.Window)
         self.resize(600, 600)
         self.setWindowTitle("Data Insight Tool")
-
-        self.plot = plot
 
         self.layout_init()
 
@@ -310,6 +308,18 @@ class DataInsightTool(QWidget):
         self.pv_select_box.currentIndexChanged.connect(self.get_data)
         self.refresh_button.clicked.connect(self.get_data)
 
+        if isinstance(plot, PyDMArchiverTimePlot):
+            self.plot = plot
+
+    @property
+    def plot(self) -> PyDMArchiverTimePlot:
+        """Return the plot associated with this widget"""
+        return self._plot
+
+    @plot.setter
+    def plot(self, plot: PyDMArchiverTimePlot) -> None:
+        """Set the plot associated with this widget"""
+        self._plot = plot
         self.update_pv_select_box()
         if self.pv_select_box.count() > 0:
             self.get_data(0)
@@ -380,7 +390,11 @@ class DataInsightTool(QWidget):
         when the plot is updated.
         """
         self.pv_select_box.clear()
-        curve_names = [c.name for c in self.plot.curves() if isinstance(c, ArchivePlotCurveItem)]
+        # curve_names = [c.address for c in self.plot.curves() if isinstance(c, ArchivePlotCurveItem)]
+        curve_names = []
+        for curve in self.plot.curves():
+            if isinstance(curve, ArchivePlotCurveItem):
+                curve_names.append(curve.address)
         self.pv_select_box.addItems(curve_names)
 
     @Slot()

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -18,7 +18,6 @@ from qtpy.QtCore import (
     QObject,
     QModelIndex,
     QAbstractTableModel,
-    QSortFilterProxyModel,
 )
 from qtpy.QtNetwork import QNetworkReply, QNetworkRequest, QNetworkAccessManager
 from qtpy.QtWidgets import (
@@ -290,40 +289,18 @@ class DataVisualizationModel(QAbstractTableModel):
                 json.dump(export_dict, file, indent=2)
 
 
-class CurveFilterModel(QSortFilterProxyModel):
-    """FilterProxyModel for trace's curves model. This proxy model filters out
-    the curves without an address and the FormulaCurveItems.
-    """
-
-    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:
-        """Determine if the given row is valid and should be presented to the user.
-        This includes ArchivePlotCurveItems that have an address.
-
-        Returns
-        -------
-        bool :
-            The row is valid and should be presented to the user
-        """
-        curve = self.sourceModel().curve_at_index(source_row)
-        return isinstance(curve, ArchivePlotCurveItem) and bool(curve.address)
-
-
 class DataInsightTool(QWidget):
     """The Data Insight Tool is a standalone widget that allows users to display
     all archive and live data on the plot for any given curve. Users are also able
     to export the raw data from this tool.
     """
 
-    def __init__(self, parent: QObject, curves_model: QAbstractTableModel, plot: PyDMArchiverTimePlot) -> None:
+    def __init__(self, parent: QObject, plot: PyDMArchiverTimePlot) -> None:
         super().__init__(parent=parent)
         self.setWindowFlag(Qt.Window)
         self.resize(600, 600)
         self.setWindowTitle("Data Insight Tool")
 
-        # Get curves model and function for getting plot x-range
-        self.curves_model = curves_model
-        self.curve_filter_model = CurveFilterModel()
-        self.curve_filter_model.setSourceModel(self.curves_model)
         self.plot = plot
 
         self.layout_init()
@@ -333,6 +310,7 @@ class DataInsightTool(QWidget):
         self.pv_select_box.currentIndexChanged.connect(self.get_data)
         self.refresh_button.clicked.connect(self.get_data)
 
+        self.update_pv_select_box()
         if self.pv_select_box.count() > 0:
             self.get_data(0)
 
@@ -344,7 +322,6 @@ class DataInsightTool(QWidget):
         self.request_layout = QHBoxLayout()
         self.pv_select_box = QComboBox()
         self.pv_select_box.setSizeAdjustPolicy(QComboBox.AdjustToContents)
-        self.pv_select_box.setModel(self.curve_filter_model)
         self.request_layout.addWidget(self.pv_select_box, alignment=Qt.AlignLeft)
 
         self.loading_label = QLabel("Loading...")
@@ -395,9 +372,16 @@ class DataInsightTool(QWidget):
         """
         if combobox_ind < 0 or self.pv_select_box.count() <= combobox_ind:
             combobox_ind = self.pv_select_box.currentIndex()
-        model_ind = self.curve_filter_model.index(combobox_ind, 0)
-        corrected_ind = self.curve_filter_model.mapToSource(model_ind)
-        return self.curves_model.curve_at_index(corrected_ind)
+        return self.plot.curveAtIndex(combobox_ind)
+
+    @Slot()
+    def update_pv_select_box(self) -> None:
+        """Populate the pv_select_box with all curves in the plot. This is called
+        when the plot is updated.
+        """
+        self.pv_select_box.clear()
+        curve_names = [c.name for c in self.plot.curves() if isinstance(c, ArchivePlotCurveItem)]
+        self.pv_select_box.addItems(curve_names)
 
     @Slot()
     def export_data_to_file(self) -> None:

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -390,11 +390,7 @@ class DataInsightTool(QWidget):
         when the plot is updated.
         """
         self.pv_select_box.clear()
-        # curve_names = [c.address for c in self.plot.curves() if isinstance(c, ArchivePlotCurveItem)]
-        curve_names = []
-        for curve in self.plot.curves():
-            if isinstance(curve, ArchivePlotCurveItem):
-                curve_names.append(curve.address)
+        curve_names = [c.address for c in self.plot._curves if isinstance(c, ArchivePlotCurveItem)]
         self.pv_select_box.addItems(curve_names)
 
     @Slot()


### PR DESCRIPTION
## Main Enhancement
- Add the `DataInsightTool` to the UI Redesign (#88)
  - The DIT's PV selection box updates when curves are added/removed so that the box only shows the available `ArchivePlotCurveItem`s
  - DIT no longer requires the curve model, it gets all data from the plot & archiver tool

## Additional Enhancement
- Signal from `ControlPanel` that is emitted whenever a curve is added/removed
  - Could be useful in the future


![Screenshot 2025-04-24 at 14 06 36](https://github.com/user-attachments/assets/56d7215f-8971-4b43-9270-8e404f7bf932)
