### PR TITLE
FIX: Fix Main Thread Hanging from caget Call

### DIFF
--- a/trace/config.py
+++ b/trace/config.py
@@ -13,10 +13,20 @@ logger = getLogger("")
 
 datetime_pv = loaded_json["datetime_pv"]
 
+# Set default save file directory
+# If the directory does not exist, set it to the home directory
 save_file_dir = Path(os.path.expandvars(loaded_json["save_file_dir"]))
 if not save_file_dir.is_dir():
     logger.warning(f"Config file's save_file_dir path does not exist: {save_file_dir}")
     save_file_dir = Path.home()
     logger.warning(f"Setting save_file_dir to home: {save_file_dir}")
 
+# Set default color palette
 color_palette = [QColor(hex_code) for hex_code in loaded_json["colors"]]
+
+# Set the default thread count for numexpr
+# 8 is determined to be a safe default for most systems according to numxerpr documentation
+numexpr_threads = os.environ.get("NUMEXPR_MAX_THREADS", None)
+if numexpr_threads is None:
+    os.environ["NUMEXPR_MAX_THREADS"] = "8"
+    logger.debug("NUMEXPR_MAX_THREADS not set, defaulting to 8")

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -60,8 +60,8 @@ class CAGetThread(QThread):
 
     result_ready = Signal(object)
 
-    def __init__(self, address: str) -> None:
-        super().__init__()
+    def __init__(self, parent: QObject = None, address: str = "") -> None:
+        super().__init__(parent=parent)
         self.address = address
         self.stop_flag = False
 
@@ -76,6 +76,7 @@ class CAGetThread(QThread):
         """Override the quit method to set the stop flag"""
         self.stop_flag = True
         super().quit()
+        self.deleteLater()
 
 
 class DataVisualizationModel(QAbstractTableModel):
@@ -159,7 +160,7 @@ class DataVisualizationModel(QAbstractTableModel):
         # Create a new CAGetThread to get the description of the curve
         if isinstance(self.caget_thread, CAGetThread) and self.caget_thread.isRunning():
             self.caget_thread.quit()
-        self.caget_thread = CAGetThread(self.address + ".DESC")
+        self.caget_thread = CAGetThread(self, self.address + ".DESC")
         self.caget_thread.result_ready.connect(self.set_description)
         self.caget_thread.start()
 

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -360,11 +360,12 @@ class DataInsightTool(QWidget):
 
     def set_meta_data(self) -> None:
         """Populate the meta_data_label with the curve's unit (if any) and description."""
-        meta_str = ""
+        meta_labels = []
         if self.data_vis_model.unit:
-            meta_str = self.data_vis_model.unit + ", "
-        meta_str += self.data_vis_model.description
-        self.meta_data_label.setText(meta_str)
+            meta_labels.append(str(self.data_vis_model.unit))
+        if self.data_vis_model.description:
+            meta_labels.append(str(self.data_vis_model.description))
+        self.meta_data_label.setText(", ".join(meta_labels))
 
     def combobox_to_curve(self, combobox_ind: int) -> ArchivePlotCurveItem:
         """Convert an index for the pv_select_box combobox to the corresponding

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -72,11 +72,9 @@ class CAGetThread(QThread):
             return
         self.result_ready.emit(value)
 
-    def quit(self) -> None:
-        """Override the quit method to set the stop flag"""
+    def stop(self) -> None:
+        """Set the stop flag"""
         self.stop_flag = True
-        super().quit()
-        self.deleteLater()
 
 
 class DataVisualizationModel(QAbstractTableModel):
@@ -159,7 +157,7 @@ class DataVisualizationModel(QAbstractTableModel):
 
         # Create a new CAGetThread to get the description of the curve
         if isinstance(self.caget_thread, CAGetThread) and self.caget_thread.isRunning():
-            self.caget_thread.quit()
+            self.caget_thread.stop()
         self.caget_thread = CAGetThread(self, self.address + ".DESC")
         self.caget_thread.result_ready.connect(self.set_description)
         self.caget_thread.start()
@@ -444,7 +442,9 @@ class DataInsightTool(QWidget):
         """Populate the pv_select_box with all curves in the plot. This is called
         when the plot is updated.
         """
+        self.pv_select_box.blockSignals(True)
         self.pv_select_box.clear()
+        self.pv_select_box.blockSignals(False)
         curve_names = [c.address for c in self.plot._curves if isinstance(c, ArchivePlotCurveItem)]
         self.pv_select_box.addItems(curve_names)
 

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -153,6 +153,9 @@ class DataVisualizationModel(QAbstractTableModel):
         self.address = curve_item.address if curve_item.address else ""
         self.unit = curve_item.units
 
+        # Set the meta data label of the DataInsightTool
+        self.set_description("Loading...")
+
         # Create a new CAGetThread to get the description of the curve
         if isinstance(self.caget_thread, CAGetThread) and self.caget_thread.isRunning():
             self.caget_thread.quit()

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -254,8 +254,11 @@ class DataVisualizationModel(QAbstractTableModel):
         self.reply_recieved.emit()
         if reply.error() == QNetworkReply.NoError:
             bytes_str = reply.readAll()
-            data_dict = json.loads(str(bytes_str, "utf-8"))
-            self.set_archive_data(data_dict)
+            try:
+                data_dict = json.loads(str(bytes_str, "utf-8"))
+                self.set_archive_data(data_dict)
+            except json.JSONDecodeError:
+                logger.warning("Data Insight Tool: No data received from archiver")
         else:
             logger.debug(
                 f"Request for data from archiver failed, request url: {reply.url()} retrieved header: "

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -188,8 +188,11 @@ class DataVisualizationModel(QAbstractTableModel):
         x_range : Iterable[int]
             The time range to collect and store data between
         """
-        data_n = curve_item.getBufferSize()
-        data = curve_item.data_buffer[:, :data_n]
+        data_n = curve_item.points_accumulated
+        if data_n == 0:
+            return
+
+        data = curve_item.data_buffer[:, -data_n:]
         indices = np.where((x_range[0] <= data[0]) & (data[0] <= x_range[1]))[0]
 
         convert_data = {"Datetime": [], "Value": [], "Severity": []}


### PR DESCRIPTION
## Main Problem
The `DataInsightTool` from #147 was causing the main thread to hang whenever a new curve was added. This came from a caget on a PV that didn't exist, resulting in the thread waiting the whole 5s timeout delay.

## Main Fix
Move the caget call to a separate worker thread. The thread is spawned from the `DataVisualizationModel`. The model saves the description as an attribute and will prompt an update of the `DataInsightTool`. The meta_data label will be populated with a "Loading..." message while waiting for a CA response. This will really only be visible when the PV doesn't exist and is waiting to timeout.

## Minor Fixes
- `DataInsightTool.set_meta_data` would throw errors if the user tried a caget call on a PV that doesn't exist. This function was trying to concatenate a `NoneType` with a `str`. Instead I am using `str.join()` to construct the meta data label text.
- The table was displaying the curve's unpopulated buffer if there was no real live data. This has been resolved.
- If the archiver tool sends an `OK` response with no data, an error was thrown. Now a warning message is logged stating that no data was received.
- In `config.py` I set the environment variable for `NUMEXPR_MAX_THREADS` if it is not already set because it not being set prints a warning on start up.