### PR TITLE
ENH: Trace Menu with Trace Specific Actions

### DIFF
--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -105,6 +105,7 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         multi_axis_plot.sigXRangeChangedManually.connect(self.disable_auto_scroll_button.click)
         plot_side_layout.addWidget(self.plot)
 
+        self.data_insight_tool = DataInsightTool(self)
         self.data_insight_tool.plot = self.plot
 
         self.settings_button = QPushButton(self.plot)
@@ -126,22 +127,11 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         tool_layout.setContentsMargins(0, 0, 0, 0)
         toolbar_widget.setLayout(tool_layout)
 
-        save_image_button = QPushButton("Save Image", toolbar_widget)
-        save_image_button.clicked.connect(self.save_plot_image)
-        tool_layout.addWidget(save_image_button)
-        elog_button = QPushButton("Send to Elog", toolbar_widget)
-        elog_button.clicked.connect(self.elog_button_clicked)
-        tool_layout.addWidget(elog_button)
         tool_spacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
         tool_layout.addSpacerItem(tool_spacer)
 
         timespan_buttons = self.build_timespan_buttons(toolbar_widget)
         tool_layout.addWidget(timespan_buttons)
-
-        self.data_insight_tool = DataInsightTool(self)
-        data_insight_tool_button = QPushButton("Data Insight Tool", toolbar_widget)
-        data_insight_tool_button.clicked.connect(self.data_insight_tool.show)
-        tool_layout.addWidget(data_insight_tool_button)
 
         return toolbar_widget
 
@@ -237,30 +227,28 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         # Create a custom menu for the application
         menu_bar: QMenuBar = app.main_window.ui.menubar
         first_menu = app.main_window.ui.menuFile.menuAction()
-        trace_menu = self.construct_trace_menu()
+        trace_menu = self.construct_trace_menu(menu_bar)
         menu_bar.insertMenu(first_menu, trace_menu)
 
-    def construct_trace_menu(self) -> QMenu:
+    def construct_trace_menu(self, parent: QMenuBar) -> QMenu:
         """Create the menu for the application."""
-        menu = QMenu("Trace")
+        menu = QMenu("Trace", parent)
         save = menu.addAction("Save", self.export_save_file)
         save.setShortcut(QKeySequence("Ctrl+S"))
         save_as = menu.addAction("Save As...", self.export_save_file)
         save_as.setShortcut(QKeySequence("Ctrl+Shift+S"))
         load = menu.addAction("Open Trace Config...", self.import_save_file)
         load.setShortcut(QKeySequence("Ctrl+O"))
-
         menu.addSeparator()
 
         save_image = menu.addAction("Save Plot Image...", self.save_plot_image)
         save_image.setShortcut(QKeySequence("Ctrl+I"))
         save_elog = menu.addAction("Save ELOG Entry...", self.elog_button_clicked)
         save_elog.setShortcut(QKeySequence("Ctrl+E"))
-
         menu.addSeparator()
+
         fetch_archive = menu.addAction("Fetch Archive Data", self.fetch_archive)
         fetch_archive.setShortcut(QKeySequence("Ctrl+F"))
-
         dit_action = menu.addAction("Data Insight Tool...", self.data_insight_tool.show)
         dit_action.setShortcut(QKeySequence("Ctrl+D"))
 

--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -59,14 +59,6 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
     def minimumSizeHint(self):
         return QSize(700, 350)
 
-    def file_menu_items(self) -> dict:
-        """Add export & import functionality to File menu"""
-        return {
-            "save": (self.export_save_file, "Ctrl+S"),
-            "save_as": (self.export_save_file, "Ctrl+Shift+S"),
-            "load": (self.import_save_file, "Ctrl+L"),
-        }
-
     def build_ui(self) -> None:
         # Set window title
         self.setWindowTitle("Trace")
@@ -237,12 +229,20 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         app.main_window.toggle_status_bar(False)
         app.main_window.ui.actionShow_Status_Bar.setChecked(False)
 
+        # Remove shortcut from the "Open File" menu action
         open_file_action = app.main_window.ui.actionOpen_File
         open_file_action.setText("Open PyDM File...")
         open_file_action.setShortcut(QKeySequence())
 
+        # Create a custom menu for the application
         menu_bar: QMenuBar = app.main_window.ui.menubar
-        menu = QMenu("Trace", menu_bar)
+        first_menu = app.main_window.ui.menuFile.menuAction()
+        trace_menu = self.construct_trace_menu()
+        menu_bar.insertMenu(first_menu, trace_menu)
+
+    def construct_trace_menu(self) -> QMenu:
+        """Create the menu for the application."""
+        menu = QMenu("Trace")
         save = menu.addAction("Save", self.export_save_file)
         save.setShortcut(QKeySequence("Ctrl+S"))
         save_as = menu.addAction("Save As...", self.export_save_file)
@@ -254,9 +254,8 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
 
         save_image = menu.addAction("Save Plot Image...", self.save_plot_image)
         save_image.setShortcut(QKeySequence("Ctrl+I"))
-        save_elog = menu.addAction("Save ELOG Entry...")  # , self.save_elog_entry)
+        save_elog = menu.addAction("Save ELOG Entry...", self.elog_button_clicked)
         save_elog.setShortcut(QKeySequence("Ctrl+E"))
-        save_elog.setEnabled(False)
 
         menu.addSeparator()
         fetch_archive = menu.addAction("Fetch Archive Data", self.fetch_archive)
@@ -265,8 +264,7 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         dit_action = menu.addAction("Data Insight Tool...", self.data_insight_tool.show)
         dit_action.setShortcut(QKeySequence("Ctrl+D"))
 
-        first_menu = app.main_window.ui.menuFile.menuAction()
-        menu_bar.insertMenu(first_menu, menu)
+        return menu
 
     @Slot()
     def save_plot_image(self) -> None:

--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -5,12 +5,14 @@ from getpass import getuser
 from datetime import datetime
 
 import qtawesome as qta
-from qtpy.QtGui import QFont, QImage
+from qtpy.QtGui import QFont, QImage, QKeySequence
 from qtpy.QtCore import Qt, Slot, QSize, Signal, QBuffer, QIODevice
 from qtpy.QtWidgets import (
+    QMenu,
     QLabel,
     QDialog,
     QWidget,
+    QMenuBar,
     QSplitter,
     QFileDialog,
     QHBoxLayout,
@@ -234,6 +236,37 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         # Hide status bar by default (can be shown in menu bar)
         app.main_window.toggle_status_bar(False)
         app.main_window.ui.actionShow_Status_Bar.setChecked(False)
+
+        open_file_action = app.main_window.ui.actionOpen_File
+        open_file_action.setText("Open PyDM File...")
+        open_file_action.setShortcut(QKeySequence())
+
+        menu_bar: QMenuBar = app.main_window.ui.menubar
+        menu = QMenu("Trace", menu_bar)
+        save = menu.addAction("Save", self.export_save_file)
+        save.setShortcut(QKeySequence("Ctrl+S"))
+        save_as = menu.addAction("Save As...", self.export_save_file)
+        save_as.setShortcut(QKeySequence("Ctrl+Shift+S"))
+        load = menu.addAction("Open Trace Config...", self.import_save_file)
+        load.setShortcut(QKeySequence("Ctrl+O"))
+
+        menu.addSeparator()
+
+        save_image = menu.addAction("Save Plot Image...", self.save_plot_image)
+        save_image.setShortcut(QKeySequence("Ctrl+I"))
+        save_elog = menu.addAction("Save ELOG Entry...")  # , self.save_elog_entry)
+        save_elog.setShortcut(QKeySequence("Ctrl+E"))
+        save_elog.setEnabled(False)
+
+        menu.addSeparator()
+        fetch_archive = menu.addAction("Fetch Archive Data", self.fetch_archive)
+        fetch_archive.setShortcut(QKeySequence("Ctrl+F"))
+
+        dit_action = menu.addAction("Data Insight Tool...", self.data_insight_tool.show)
+        dit_action.setShortcut(QKeySequence("Ctrl+D"))
+
+        first_menu = app.main_window.ui.menuFile.menuAction()
+        menu_bar.insertMenu(first_menu, menu)
 
     @Slot()
     def save_plot_image(self) -> None:

--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -57,6 +57,14 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
     def minimumSizeHint(self):
         return QSize(700, 350)
 
+    def file_menu_items(self) -> dict:
+        """Add export & import functionality to File menu"""
+        return {
+            "save": (self.export_save_file, "Ctrl+S"),
+            "save_as": (self.export_save_file, "Ctrl+Shift+S"),
+            "load": (self.import_save_file, "Ctrl+L"),
+        }
+
     def build_ui(self) -> None:
         # Set window title
         self.setWindowTitle("Trace")


### PR DESCRIPTION
## Description
This PR adds a menu to the applications menu bar titled "Trace". The Trace menu contains actions that are relevant to the application. All actions added to the Trace menu are also assigned a keyboard shortcut.

The exact actions in the menu are listed below:
- Save, Save As, and Open for trace config files (*.trc)
  - Note: these actions don't actually work yet, but these are a place holder
- Save Plot Image
  - The Save Plot Image button is removed from the toolbar
- Save ELOG Entry
  - The Save ELOG Entry button is removed from the toolbar
- Fetch Archive Data
- Data Insight Tool
  - The Data Insight Tool button is removed from the toolbar

closes #126 

<img width="722" alt="Screenshot 2025-05-27 at 15 20 54" src="https://github.com/user-attachments/assets/3adfe764-9872-4220-90f3-1bbc693e3cc5" />
