### PR TITLE
GUI: make splitter handle visible

### DIFF
--- a/trace/ui_redesign_test.py
+++ b/trace/ui_redesign_test.py
@@ -67,6 +67,7 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         # Create the plotting and control widgets
         plot_side_widget = self.build_plot_side(self)
         control_panel = ControlPanel()
+        control_panel.layout().setContentsMargins(8, 0, 0, 0)
         control_panel.plot = self.plot
         control_panel.curve_list_changed.connect(self.data_insight_tool.update_pv_select_box)
 
@@ -76,6 +77,16 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
         main_splitter.addWidget(control_panel)
         main_splitter.setCollapsible(0, False)
         main_splitter.setStretchFactor(0, 1)
+        main_splitter.setHandleWidth(10)
+        main_splitter.setStyleSheet(
+            "\n".join(
+                [
+                    "QSplitter::handle {",
+                    "  background-color: white;",
+                    "}",
+                ]
+            )
+        )
         main_layout.addWidget(main_splitter)
 
         # Create the footer section of the app
@@ -85,6 +96,7 @@ class TraceDisplay(Display, FileIOMixin, PlotConfigMixin):
     def build_plot_side(self, parent):
         plot_side_widget = QWidget(parent)
         plot_side_layout = QVBoxLayout()
+        plot_side_layout.setContentsMargins(0, 0, 8, 0)
         plot_side_widget.setLayout(plot_side_layout)
 
         toolbar = self.build_toolbar(plot_side_widget)

--- a/trace/widgets/control_panel.py
+++ b/trace/widgets/control_panel.py
@@ -14,6 +14,7 @@ class ControlPanel(QtWidgets.QWidget):
     def __init__(self):
         super().__init__()
         self.setLayout(QtWidgets.QVBoxLayout())
+        self.setStyleSheet("background-color: white;")
 
         # Create pv plotter layout
         pv_plotter_layout = QtWidgets.QHBoxLayout()


### PR DESCRIPTION
## Description
Uses the same background color as the plot, and changes the background color of the control panel, to match mock-ups. Adjusts content margins to look even.

Closes [SWAPPS-251](https://jira.slac.stanford.edu/browse/SWAPPS-251)
## Screenshots
Before
![Screenshot 2025-05-28 at 09 40 25](https://github.com/user-attachments/assets/5fb194d7-01dd-4fee-abc7-862b37f1149d)

After
![Screenshot 2025-05-28 at 09 40 02](https://github.com/user-attachments/assets/daa34a84-2750-479d-97f0-f72ad0960a2b)