### PR TITLE
ENH: Tick Font Size Sets Y-Axes Tick Font As Well

### DIFF
--- a/trace/widgets/control_panel.py
+++ b/trace/widgets/control_panel.py
@@ -102,6 +102,7 @@ class ControlPanel(QtWidgets.QWidget):
 
     def add_axis_item(self, axis: BasePlotAxisItem) -> "AxisItem":
         """Add an existing AxisItem to the plot."""
+        self.match_axis_tick_font(axis)
         axis_item = AxisItem(axis)
         axis_item.curves_list_changed.connect(self.curve_list_changed.emit)
         self.axis_list.insertWidget(self.axis_list.count() - 1, axis_item)
@@ -109,6 +110,18 @@ class ControlPanel(QtWidgets.QWidget):
         self.updateGeometry()
 
         return axis_item
+
+    def match_axis_tick_font(self, axis: BasePlotAxisItem) -> None:
+        """Matches the axis' tick font to the X-Axis of the plot. Only necessary
+        if the user has changed the tick font of the plot's axes.
+
+        Parameters
+        ----------
+        axis : BasePlotAxisItem
+            The axis to match the tick font for."""
+        x_axis = self.plot.getAxis("bottom")
+        if x_axis is not None:
+            axis.setTickFont(x_axis.style["tickFont"])
 
     def get_axis_item(self, axis_name: str) -> "AxisItem":
         """Get an AxisItem by its name."""

--- a/trace/widgets/plot_settings.py
+++ b/trace/widgets/plot_settings.py
@@ -92,12 +92,12 @@ class PlotSettingsModal(QWidget):
         background_row = SettingsRowItem(self, "  Background Color", self.background_button)
         main_layout.addLayout(background_row)
 
-        x_axis_font_size_spinbox = QSpinBox(self)
-        x_axis_font_size_spinbox.setValue(12)
-        x_axis_font_size_spinbox.setSuffix(" pt")
-        x_axis_font_size_spinbox.valueChanged.connect(self.set_x_axis_font_size)
-        x_axis_font_size_row = SettingsRowItem(self, "  X Axis Font Size", x_axis_font_size_spinbox)
-        main_layout.addLayout(x_axis_font_size_row)
+        axis_tick_font_size_spinbox = QSpinBox(self)
+        axis_tick_font_size_spinbox.setValue(12)
+        axis_tick_font_size_spinbox.setSuffix(" pt")
+        axis_tick_font_size_spinbox.valueChanged.connect(self.set_axis_tick_font_size)
+        axis_tick_font_size_row = SettingsRowItem(self, "  Axis Tick Font Size", axis_tick_font_size_spinbox)
+        main_layout.addLayout(axis_tick_font_size_row)
 
         self.x_grid_checkbox = QCheckBox(self)
         self.x_grid_checkbox.stateChanged.connect(self.show_x_grid)
@@ -145,11 +145,13 @@ class PlotSettingsModal(QWidget):
         super().show()
 
     @Slot(int)
-    def set_x_axis_font_size(self, size: int) -> None:
+    def set_axis_tick_font_size(self, size: int) -> None:
         font = QFont()
         font.setPixelSize(size)
-        x_axis = self.plot.getAxis("bottom")
-        x_axis.setStyle(tickFont=font)
+
+        all_axes = self.plot.plotItem.getAxes()
+        for axis in all_axes:
+            axis.setStyle(tickFont=font)
 
     @Slot(object)
     def set_time_axis_range(self, raw_range: tuple[QDateTime, QDateTime] = (None, None)) -> None:


### PR DESCRIPTION
## Description
Previously, the `x_axis_font_size_spinbox` only affected the font size for ticks on the X-Axis. This PR will set the font size for ticks of all axes. This also sets the font size of new axes to match the font size of existing axes.

## Motivation
This was requested in a meeting in October. Part of the reason behind the request was because Trace looked odd when the font was larger for only one axis.

Closes #74 
Closes [SWAPPS-51](https://jira.slac.stanford.edu/browse/SWAPPS-51)

## Screenshots

Before: Only the font size for the X-Axis changed
![Screenshot 2025-07-02 at 14 01 50](https://github.com/user-attachments/assets/15be1c9d-b2e4-4fef-8261-4ce656c00898)

After: Set the font size for all axes (X & Y)
![Screenshot 2025-07-02 at 14 01 08](https://github.com/user-attachments/assets/64b37e83-7b3f-4e1a-86c1-4dc6da415859)

After: Change the setting name in PlotSettingsModal changed from "X Axis Font Size" to "Axis Tick Font Size"
![Screenshot 2025-07-02 at 14 01 01](https://github.com/user-attachments/assets/875d5e4c-6365-4928-95b7-4edc72fa3854)
