### PR TITLE
ENH: TraceFileConvert Can Export Relative Times

### DIFF
--- a/trace/file_io/time_parser.py
+++ b/trace/file_io/time_parser.py
@@ -83,6 +83,50 @@ class IOTimeParser:
         return td
 
     @classmethod
+    def delta_to_relative(cls, delta: datetime.timedelta) -> str:
+        """Convert a datetime.timedelta to a relative time string
+
+        Parameters
+        ----------
+        delta : datetime.timedelta
+            The timedelta to convert
+
+        Returns
+        -------
+        str
+            A string representing the timedelta in a relative format
+        """
+        return_list = []
+        remaining_seconds = int(delta.total_seconds())
+
+        negative = False
+        if remaining_seconds < 0:
+            negative = True
+            remaining_seconds = abs(remaining_seconds)
+
+        years, remaining_seconds = divmod(remaining_seconds, 365 * 24 * 3600)
+        return_list.append(f"{'-' if negative else '+'}{int(years)}y" if years else "")
+
+        months, remaining_seconds = divmod(remaining_seconds, 30 * 24 * 3600)
+        return_list.append(f"{'-' if negative else '+'}{int(months)}M" if months else "")
+
+        weeks, remaining_seconds = divmod(remaining_seconds, 7 * 24 * 3600)
+        return_list.append(f"{'-' if negative else '+'}{int(weeks)}w" if weeks else "")
+
+        days, remaining_seconds = divmod(remaining_seconds, 24 * 3600)
+        return_list.append(f"{'-' if negative else '+'}{int(days)}d" if days else "")
+
+        hours, remaining_seconds = divmod(remaining_seconds, 3600)
+        return_list.append(f"{'-' if negative else '+'}{int(hours)}H" if hours else "")
+
+        minutes, seconds = divmod(remaining_seconds, 60)
+        return_list.append(f"{'-' if negative else '+'}{int(minutes)}m" if minutes else "")
+        return_list.append(f"{'-' if negative else '+'}{int(seconds)}s" if seconds else "")
+
+        return_list = [item for item in return_list if item]  # Remove empty strings
+        return " ".join(return_list) if return_list else "-1d"  # Default to -1 day if no time is given
+
+    @classmethod
     def set_time_on_datetime(cls, dt: datetime.datetime, time_str: str) -> datetime.datetime:
         """Set an absolute time on a datetime object
 


### PR DESCRIPTION
## Description
Before this PR, if a user enabled autoscrolling and then saved the file, the x-range timespan was only saved as absolute times. This is not what the user would expect and would be unhelpful when loading a file.

This PR will allow `TraceFileConvert` to export the timespan as a relative time. This relative time will be in the right format to enable autoscroll when a user imports the given file.


## Motivation
Closes #122 
Closes Jira ticket: [SWAPPS-50](https://jira.slac.stanford.edu/browse/SWAPPS-50)

## Example output:
```
"time_axis": {
"name": "Main Time Axis",
"start": "-1M -10H -5m",
"end": "now",
"location": "bottom"
}
```