### PR TITLE
Implement attaching config file to elog entry

### DIFF
--- a/trace/main.py
+++ b/trace/main.py
@@ -338,12 +338,17 @@ class TraceDisplay(Display):
         # Get entry info from user
         dialog = ElogPostModal.maybe_create(self, image_bytes=image_bytes)
         if dialog is not None and dialog.exec_() == QDialog.Accepted:
-            title, body, logbooks = dialog.get_inputs()
+            title, body, logbooks, attach_config = dialog.get_inputs()
         else:
             return False
 
+        config_file_path = None
+        if attach_config:
+            self.file_handler.save_file()
+            config_file_path = self.file_handler.current_file
+
         # Post the request to the Elog API
-        status_code, _ = post_entry(title, body, logbooks, image_bytes)
+        status_code, _ = post_entry(title, body, logbooks, image_bytes, config_file_path)
 
         # Check if the request was successful
         if status_code == 201:

--- a/trace/widgets/elog_post_modal.py
+++ b/trace/widgets/elog_post_modal.py
@@ -3,6 +3,7 @@ from qtpy.QtWidgets import (
     QLabel,
     QDialog,
     QWidget,
+    QCheckBox,
     QLineEdit,
     QTextEdit,
     QListWidget,
@@ -66,6 +67,10 @@ class ElogPostModal(QDialog):
         )
         main_layout.addLayout(logbook_readback_row)
 
+        self.attach_config_checkbox = QCheckBox(self)
+        attach_config_row = SettingsRowItem(self, "Attach config", self.attach_config_checkbox)
+        main_layout.addLayout(attach_config_row)
+
         buttons = QDialogButtonBox()
         send_button = buttons.addButton("Send", QDialogButtonBox.AcceptRole)
         cancel_button = buttons.addButton(QDialogButtonBox.Cancel)
@@ -79,7 +84,7 @@ class ElogPostModal(QDialog):
         Handles the submission of the dialog. This method is called when the user clicks the 'Send' button.
         It retrieves the inputs, validates, and closes the dialog.
         """
-        title, _, logbooks = self.get_inputs()
+        title, _, logbooks, _ = self.get_inputs()
         if not title:
             QMessageBox.warning(self, "Input Error", "Title is required.")
             return
@@ -89,14 +94,15 @@ class ElogPostModal(QDialog):
 
         self.accept()
 
-    def get_inputs(self) -> tuple[str, str, list[str]]:
+    def get_inputs(self) -> tuple[str, str, list[str], bool]:
         """
         Returns the inputs from the dialog as a tuple of (title, body, logbooks).
         """
         title = self.title_edit.text().strip()
         body = self.body_edit.toPlainText().strip()
         logbooks = [item.text() for item in self.logbook_list.selectedItems()]
-        return title, body, logbooks
+        attach_config = self.attach_config_checkbox.isChecked()
+        return title, body, logbooks, attach_config
 
     @classmethod
     def maybe_create(cls, parent: QWidget = None, image_bytes: bytes | None = None) -> "ElogPostModal | None":

--- a/trace/widgets/elog_post_modal.py
+++ b/trace/widgets/elog_post_modal.py
@@ -68,7 +68,7 @@ class ElogPostModal(QDialog):
         main_layout.addLayout(logbook_readback_row)
 
         self.attach_config_checkbox = QCheckBox(self)
-        attach_config_row = SettingsRowItem(self, "Attach config", self.attach_config_checkbox)
+        attach_config_row = SettingsRowItem(self, "Attach Config", self.attach_config_checkbox)
         main_layout.addLayout(attach_config_row)
 
         buttons = QDialogButtonBox()
@@ -96,7 +96,7 @@ class ElogPostModal(QDialog):
 
     def get_inputs(self) -> tuple[str, str, list[str], bool]:
         """
-        Returns the inputs from the dialog as a tuple of (title, body, logbooks).
+        Returns the inputs from the dialog as a tuple of (title, body, logbooks, attach_config).
         """
         title = self.title_edit.text().strip()
         body = self.body_edit.toPlainText().strip()


### PR DESCRIPTION
Adds an additional option to the elog entry dialog to attach the config file to the post. It uses the existing save_file method, so that should all work as expected, including saving a new config file if needed.

<img width="431" height="749" alt="image" src="https://github.com/user-attachments/assets/863f9863-8c73-4ccf-98fd-30c89d6a454a" />

A demo entry with config:
https://accel-webapp-dev.slac.stanford.edu/elog/6887f4cf49a1554a087dffc8
<img width="433" height="752" alt="image" src="https://github.com/user-attachments/assets/1daf2390-298a-4824-8a57-87dcba2fae9a" />


closes #170 