### PR TITLE
Reduce footer info and add imported filename

### DIFF
--- a/trace/file_io/file_handler.py
+++ b/trace/file_io/file_handler.py
@@ -18,6 +18,7 @@ class TraceFileHandler(QObject):
     plot_settings_signal = Signal(dict)
     timerange_signal = Signal(tuple)
     auto_scroll_span_signal = Signal(float)
+    file_loaded_signal = Signal(Path)
 
     def __init__(self, plot: PyDMArchiverTimePlot, parent=None):
         """Initialize the File IO Manager, which is responsible for managing
@@ -88,6 +89,7 @@ class TraceFileHandler(QObject):
             file_data = self.converter.import_file(file_path)
             self.current_file = file_path
             self.current_dir = file_path.parent
+            logger.info(f"Successfully loaded file: {file_path}")
         except (FileNotFoundError, ValueError) as e:
             logger.error(str(e))
             self.open_file()
@@ -128,6 +130,7 @@ class TraceFileHandler(QObject):
         self.axes_signal.emit(file_data["y-axes"])
         self.curves_signal.emit(file_data["curves"] + file_data["formula"])
         self.plot_settings_signal.emit(file_data["plot"])
+        self.file_loaded_signal.emit(file_path)
 
         # Prompt a change to the X-axis timerange
         if end_str == "now":

--- a/trace/main.py
+++ b/trace/main.py
@@ -208,10 +208,7 @@ class TraceDisplay(Display):
         footer_info_layout.setContentsMargins(0, 0, 0, 0)
 
         footer_label_data = (
-            (self.git_version(), "Trace Version"),
             (gethostname(), "Node Name"),
-            (getuser(), "User Name"),
-            (str(os.getpid()), "PID"),
             (os.getenv("PYDM_ARCHIVER_URL"), "Archiver URL"),
         )
 

--- a/trace/main.py
+++ b/trace/main.py
@@ -231,7 +231,7 @@ class TraceDisplay(Display):
         footer_layout.addWidget(self.time_label)
 
         return footer_widget
-    
+
     def set_file_indicator(self, file_path: str) -> None:
         """Set the file indicator label to the given file path."""
         if not file_path:

--- a/trace/main.py
+++ b/trace/main.py
@@ -192,14 +192,20 @@ class TraceDisplay(Display):
         return timespan_button_widget
 
     def build_footer(self, parent: QWidget):
-        label_font = QFont()
-        label_font.setPointSize(8)
+        self.footer_label_font = QFont()
+        self.footer_label_font.setPointSize(8)
 
         footer_widget = QWidget(parent)
         footer_widget.setFixedHeight(12)
         footer_layout = QHBoxLayout()
         footer_layout.setContentsMargins(0, 0, 0, 0)
         footer_widget.setLayout(footer_layout)
+
+        # Left side of footer, with various info labels
+        self.footer_info_widget = QWidget(footer_widget)
+        footer_layout.addWidget(self.footer_info_widget)
+        footer_info_layout = QHBoxLayout(self.footer_info_widget)
+        footer_info_layout.setContentsMargins(0, 0, 0, 0)
 
         footer_label_data = (
             (self.git_version(), "Trace Version"),
@@ -210,15 +216,15 @@ class TraceDisplay(Display):
         )
 
         for text, tooltip in footer_label_data:
-            label = QLabel(text, footer_widget)
-            label.setFont(label_font)
+            label = QLabel(text, self.footer_info_widget)
+            label.setFont(self.footer_label_font)
             label.setToolTip(tooltip)
             label.setAlignment(Qt.AlignBottom)
-            footer_layout.addWidget(label)
-            footer_layout.addWidget(BreakerLabel(footer_widget))
+            footer_info_layout.addWidget(label)
+            footer_info_layout.addWidget(BreakerLabel(self.footer_info_widget))
 
-        last_breaker = footer_widget.children()[-1]
-        footer_layout.removeWidget(last_breaker)
+        last_breaker = self.footer_info_widget.children()[-1]
+        footer_info_layout.removeWidget(last_breaker)
 
         footer_spacer = QSpacerItem(40, 12, QSizePolicy.Expanding, QSizePolicy.Minimum)
         footer_layout.addSpacerItem(footer_spacer)
@@ -228,6 +234,20 @@ class TraceDisplay(Display):
         footer_layout.addWidget(self.time_label)
 
         return footer_widget
+    
+    def set_file_indicator(self, file_path: str) -> None:
+        """Set the file indicator label to the given file path."""
+        if not file_path:
+            return
+        filename = os.path.basename(file_path)
+        if hasattr(self, "file_label") and self.file_label is not None:
+            self.file_label.setText(filename)
+        else:
+            self.footer_info_widget.layout().addWidget(BreakerLabel(self.footer_info_widget))
+            self.file_label = QLabel(filename, self.footer_info_widget)
+            self.file_label.setFont(self.footer_label_font)
+            self.file_label.setToolTip("Currently loaded file")
+            self.footer_info_widget.layout().addWidget(self.file_label)
 
     def configure_app(self):
         """UI changes to be made to the PyDMApplication"""
@@ -250,6 +270,7 @@ class TraceDisplay(Display):
         self.file_handler.plot_settings_signal.connect(self.plot_settings.plot_setup)
         self.file_handler.auto_scroll_span_signal.connect(self.set_auto_scroll_span)
         self.file_handler.timerange_signal.connect(self.set_plot_timerange)
+        self.file_handler.file_loaded_signal.connect(self.set_file_indicator)
 
         # Remove shortcut from the "Open File" menu action
         open_file_action = app.main_window.ui.actionOpen_File


### PR DESCRIPTION
- When a file is loaded, adds the filename in the footer next to the archiver url
  - Added file_loaded_signal to TraceFileHandler
  - On receiving the signal, the main window creates a QLabel with the filename and adds it to the footer, or changes the text if already created
- Removed version, username, and PID so that without loaded filename the footer info only includes node name and archiver url