### PR TITLE
MNT: Python 3.9 Typehinting Compatibility

### DIFF
--- a/trace/services/elog_client.py
+++ b/trace/services/elog_client.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import requests
 from dotenv import load_dotenv
 
+from config import logger
+
 load_dotenv()
 ELOG_API_URL = os.getenv("SWAPPS_TRACE_ELOG_API_URL")
 ELOG_API_KEY = os.getenv("SWAPPS_TRACE_ELOG_API_KEY")
@@ -29,7 +31,7 @@ def get_user() -> Tuple[int, Union[Dict, Exception]]:
         response.raise_for_status()
         return response.status_code, response.json()
     except requests.exceptions.RequestException as e:
-        print(e)
+        logger.error(e)
         return response.status_code, e
 
 
@@ -69,7 +71,7 @@ def post_entry(
         response.raise_for_status()
         return response.status_code, response.json()
     except requests.exceptions.RequestException as e:
-        print(e)
+        logger.error(e)
         return response.status_code, e
 
 
@@ -87,5 +89,5 @@ def get_logbooks() -> Tuple[int, Union[List[str] | Exception]]:
         response.raise_for_status()
         return response.status_code, [logbook["name"] for logbook in response.json()["payload"]]
     except requests.exceptions.RequestException as e:
-        print(e)
+        logger.error(e)
         return response.status_code, e

--- a/trace/services/elog_client.py
+++ b/trace/services/elog_client.py
@@ -6,6 +6,7 @@ Elog API client for posting entries and fetching user and logbook information.
 
 import os
 import json
+from typing import Dict, List, Tuple, Union, Optional
 from pathlib import Path
 
 import requests
@@ -16,7 +17,7 @@ ELOG_API_URL = os.getenv("SWAPPS_TRACE_ELOG_API_URL")
 ELOG_API_KEY = os.getenv("SWAPPS_TRACE_ELOG_API_KEY")
 
 
-def get_user() -> tuple[int, dict | Exception]:
+def get_user() -> Tuple[int, Union[Dict, Exception]]:
     """
     Fetches the user information from the ELOG API. Also used to verify the API key.
     :return: A tuple containing the status code and the user data or exception.
@@ -33,8 +34,8 @@ def get_user() -> tuple[int, dict | Exception]:
 
 
 def post_entry(
-    title: str, body: str, logbooks: list[str], image_bytes, config_file_path: Path | None = None
-) -> tuple[int, dict | Exception]:
+    title: str, body: str, logbooks: list[str], image_bytes, config_file_path: Optional[Path] = None
+) -> Tuple[int, Union[Dict, Exception]]:
     """
     Posts a new entry with image to the ELOG API.
 
@@ -72,7 +73,7 @@ def post_entry(
         return response.status_code, e
 
 
-def get_logbooks() -> tuple[int, list[str] | Exception]:
+def get_logbooks() -> Tuple[int, Union[List[str] | Exception]]:
     """
     Fetches the list of logbooks from the ELOG API.
 

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from qtpy.QtGui import QColor
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QWidget, QCheckBox, QLineEdit, QVBoxLayout
@@ -96,7 +98,7 @@ class CurveSettingsModal(QWidget):
         self.curve.color = color
 
     @Slot(object)
-    def set_curve_type(self, curve_type: str | None) -> None:
+    def set_curve_type(self, curve_type: Optional[str]) -> None:
         self.curve.stepMode = curve_type
 
     @Slot(object)

--- a/trace/widgets/elog_post_modal.py
+++ b/trace/widgets/elog_post_modal.py
@@ -1,3 +1,5 @@
+from typing import List, Tuple, Optional
+
 from qtpy.QtGui import QPixmap
 from qtpy.QtWidgets import (
     QLabel,
@@ -21,7 +23,7 @@ class ElogPostModal(QDialog):
     def __init__(
         self,
         parent: QWidget = None,
-        image_bytes: bytes | None = None,
+        image_bytes: Optional[bytes] = None,
     ):
         super().__init__(parent)
 
@@ -94,7 +96,7 @@ class ElogPostModal(QDialog):
 
         self.accept()
 
-    def get_inputs(self) -> tuple[str, str, list[str], bool]:
+    def get_inputs(self) -> Tuple[str, str, List[str], bool]:
         """
         Returns the inputs from the dialog as a tuple of (title, body, logbooks, attach_config).
         """
@@ -105,7 +107,7 @@ class ElogPostModal(QDialog):
         return title, body, logbooks, attach_config
 
     @classmethod
-    def maybe_create(cls, parent: QWidget = None, image_bytes: bytes | None = None) -> "ElogPostModal | None":
+    def maybe_create(cls, parent: QWidget = None, image_bytes: Optional[bytes] = None) -> Optional["ElogPostModal"]:
         """
         Creates and shows the ElogPostModal dialog if the logbook list can be populated.
         """

--- a/trace/widgets/settings_components.py
+++ b/trace/widgets/settings_components.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Tuple, Union, Optional
+
 from qtpy.QtGui import QFont
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
@@ -35,7 +37,9 @@ class SettingsRowItem(QHBoxLayout):
 class ComboBoxWrapper(QComboBox):
     text_changed = Signal(object)
 
-    def __init__(self, parent: QWidget, data_source: list | tuple | dict, init_value: int | str = None):
+    def __init__(
+        self, parent: QWidget, data_source: Union[List, Tuple, Dict], init_value: Optional[Union[int, str]] = None
+    ):
         super().__init__(parent)
         if isinstance(data_source, (list, tuple)):
             data_source = {v: v for v in data_source}


### PR DESCRIPTION
## Description
Use the `typing` library for typehinting in compliance with Trace's requirement of Python 3.9. Hopefully we can upgrade to a newer version of Python sooner, but unsure since Trace is intended to be used by a wide range of labs.