### PR TITLE
MNT: Upgrade Python to 3.12

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: [3.12]
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.12]
-        pyqt-version: [5.12.3, 5.15.7]
+        pyqt-version: [5]
     env:
       DISPLAY: ':99.0'
       QT_MAC_WANTS_LAYER: 1  # PyQT gui tests involving qtbot interaction on macOS will fail without this

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9]
+        python-version: [3.12]
         pyqt-version: [5.12.3, 5.15.7]
     env:
       DISPLAY: ':99.0'

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: trace-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python=3.12
   - pydm
   - pandas
   - pytest

--- a/trace/file_io/file_handler.py
+++ b/trace/file_io/file_handler.py
@@ -1,5 +1,4 @@
 from os import getenv
-from typing import Union
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -66,7 +65,7 @@ class TraceFileHandler(QObject):
     @Slot()
     @Slot(str)
     @Slot(Path)
-    def open_file(self, file_name: Union[str, Path] = None) -> None:
+    def open_file(self, file_name: str | Path = None) -> None:
         """Prompt the user for which config file to load from"""
         # Get the save file from the user
         if not file_name:

--- a/trace/file_io/time_parser.py
+++ b/trace/file_io/time_parser.py
@@ -1,6 +1,5 @@
 import datetime
 from re import compile
-from typing import Tuple
 
 from config import logger
 
@@ -112,7 +111,7 @@ class IOTimeParser:
         return dt
 
     @classmethod
-    def parse_times(cls, start_str: str, end_str: str) -> Tuple[datetime.datetime, datetime.datetime]:
+    def parse_times(cls, start_str: str, end_str: str) -> tuple[datetime.datetime, datetime.datetime]:
         """Convert 2 strings containing a start and end date & time, return the
         values' datetime objects. The strings can be formatted as either absolute
         times or relative times. Both are needed as relative times may be relative
@@ -127,7 +126,7 @@ class IOTimeParser:
 
         Returns
         -------
-        Tuple[datetime, datetime]
+        tuple[datetime, datetime]
             The python datetime objects for the exact start and end datetimes referenced
 
         Raises

--- a/trace/file_io/trace_file_convert.py
+++ b/trace/file_io/trace_file_convert.py
@@ -6,7 +6,6 @@ import logging
 import xml.etree.ElementTree as ET
 from os import path, getenv
 from re import compile
-from typing import Dict, List, Union
 from pathlib import Path
 from argparse import Action, Namespace, ArgumentParser
 from datetime import datetime, timedelta
@@ -38,7 +37,7 @@ class TraceFileConverter:
     java_date_re = compile(r"^[01]\d/[0-3]\d/\d{4}")
     time_re = compile(r"(?:[01]\d|2[0-3])(?::[0-5]\d)(?::[0-5]\d(?:.\d*)?)?")
 
-    def __init__(self, input_file: Union[str, Path] = "", output_file: Union[str, Path] = "") -> None:
+    def __init__(self, input_file: str | Path = "", output_file: str | Path = "") -> None:
         self.input_file = input_file
         self.output_file = output_file
 
@@ -54,7 +53,7 @@ class TraceFileConverter:
         with self.input_file.open() as f:
             return f.readline().startswith("StripConfig")
 
-    def import_file(self, file_name: Union[str, Path] = None) -> Dict:
+    def import_file(self, file_name: str | Path = None) -> dict:
         """Import Archive Viewer save data from the provided file. The file
         should be one of two types: '.trc' or '.xml'. The data is returned as
         well as saved in the stored_data property.
@@ -90,7 +89,7 @@ class TraceFileConverter:
 
         return self.stored_data
 
-    def export_file(self, file_name: Union[str, Path] = None, output_data: Union[Dict, PyDMTimePlot] = None) -> None:
+    def export_file(self, file_name: str | Path = None, output_data: dict | PyDMTimePlot = None) -> None:
         """Export the provided Archive Viewer save data to the provided file.
         The file to export to should be of type '.trc'. The provided data can
         be either a dictionary or a PyDMTimePlot object. If no data is provided,
@@ -132,7 +131,7 @@ class TraceFileConverter:
         with open(self.output_file, "w") as f:
             json.dump(output_data, f, indent=4)
 
-    def convert_xml_data(self, data_in: Dict = {}) -> Dict:
+    def convert_xml_data(self, data_in: dict = {}) -> dict:
         """Convert the inputted data from being formatted for the Java Archive
         Viewer to a format used by trace. This is accomplished by converting one
         dictionary structure to another.
@@ -212,7 +211,7 @@ class TraceFileConverter:
         self.stored_data = self.remove_null_values(converted_data)
         return self.stored_data
 
-    def convert_stp_data(self, data_in: Dict = {}) -> Dict:
+    def convert_stp_data(self, data_in: dict = {}) -> dict:
         """Convert the inputted data from a format used by StripTool to a format
         used by Trace. This is accomplished by converting one dictionary structure
         to another.
@@ -317,7 +316,7 @@ class TraceFileConverter:
         return formatted_date
 
     @staticmethod
-    def xml_to_dict(xml: ET.ElementTree) -> Dict:
+    def xml_to_dict(xml: ET.ElementTree) -> dict:
         """Convert an XML ElementTree containing an Archive Viewer save
         file to a dictionary for easier use
 
@@ -365,7 +364,7 @@ class TraceFileConverter:
         return data_dict
 
     @staticmethod
-    def stp_to_dict(stp_text: str) -> Dict:
+    def stp_to_dict(stp_text: str) -> dict:
         """Convert the StripTool file's text into a dictionary.
 
         Parameters
@@ -535,7 +534,7 @@ class TraceFileConverter:
         return QColor(srgb)
 
     @staticmethod
-    def xColor_to_qColor(rgb: List[str]) -> QColor:
+    def xColor_to_qColor(rgb: list[str]) -> QColor:
         """Convert XColor values into QColors. Colors in StripTool files (*.stp)
         are saved as XColors.
 
@@ -555,7 +554,7 @@ class TraceFileConverter:
         return QColor(*rgb)
 
     @staticmethod
-    def remove_null_values(obj_in: Union[Dict, List]) -> Union[Dict, List]:
+    def remove_null_values(obj_in: dict | list) -> dict | list:
         """Delete None values recursively from all of the dictionaries, tuples, lists, sets
 
         Parameters
@@ -594,9 +593,9 @@ def convert(converter: TraceFileConverter, input_file: Path = None, output_file:
     ----------
     converter : TraceFileConverter
         The TraceFileConverter object to use for the conversion.
-    input_file : List[Path]
+    input_file : list[Path]
         The user provided input file to be converted
-    output_file : List[Path], optional
+    output_file : list[Path], optional
         The user provided output file name to use during conversion, by default None
     overwrite : bool, optional
         Whether or not to overwrite the existing output file, by default False
@@ -625,15 +624,15 @@ def convert(converter: TraceFileConverter, input_file: Path = None, output_file:
     converter.export_file(output_file)
 
 
-def main(input_file: List[Path] = None, output_file: List[Path] = None, overwrite: bool = False, clean: bool = False):
+def main(input_file: list[Path] = None, output_file: list[Path] = None, overwrite: bool = False, clean: bool = False):
     """Convert all provided input files into the expected output files. If requested,
     overwrite the existing output files and remove any leftover input files.
 
     Parameters
     ----------
-    input_file : List[Path]
+    input_file : list[Path]
         The user provided input files to be converted
-    output_file : List[Path], optional
+    output_file : list[Path], optional
         The user provided output file names to use during conversion, by default None
     overwrite : bool, optional
         Whether or not to overwrite the existing output files, by default False
@@ -666,7 +665,7 @@ def main(input_file: List[Path] = None, output_file: List[Path] = None, overwrit
 
 class PathAction(Action):
     def __call__(
-        self, parser: ArgumentParser, namespace: Namespace, values: Union[str, List], option_string: str = None
+        self, parser: ArgumentParser, namespace: Namespace, values: str | list, option_string: str = None
     ) -> None:
         """Convert filepath string from argument into  a pathlib.Path object"""
         if isinstance(values, str):

--- a/trace/services/elog_client.py
+++ b/trace/services/elog_client.py
@@ -6,7 +6,6 @@ Elog API client for posting entries and fetching user and logbook information.
 
 import os
 import json
-from typing import Dict, List, Tuple, Union, Optional
 from pathlib import Path
 
 import requests
@@ -19,7 +18,7 @@ ELOG_API_URL = os.getenv("SWAPPS_TRACE_ELOG_API_URL")
 ELOG_API_KEY = os.getenv("SWAPPS_TRACE_ELOG_API_KEY")
 
 
-def get_user() -> Tuple[int, Union[Dict, Exception]]:
+def get_user() -> tuple[int, dict | Exception]:
     """
     Fetches the user information from the ELOG API. Also used to verify the API key.
     :return: A tuple containing the status code and the user data or exception.
@@ -36,8 +35,8 @@ def get_user() -> Tuple[int, Union[Dict, Exception]]:
 
 
 def post_entry(
-    title: str, body: str, logbooks: list[str], image_bytes, config_file_path: Optional[Path] = None
-) -> Tuple[int, Union[Dict, Exception]]:
+    title: str, body: str, logbooks: list[str], image_bytes, config_file_path: Path | None = None
+) -> tuple[int, dict | Exception]:
     """
     Posts a new entry with image to the ELOG API.
 
@@ -75,7 +74,7 @@ def post_entry(
         return response.status_code, e
 
 
-def get_logbooks() -> Tuple[int, Union[List[str], Exception]]:
+def get_logbooks() -> tuple[int, list[str] | Exception]:
     """
     Fetches the list of logbooks from the ELOG API.
 

--- a/trace/widgets/archive_search.py
+++ b/trace/widgets/archive_search.py
@@ -1,6 +1,6 @@
 import logging
 from os import getenv
-from typing import Any, List
+from typing import Any
 
 from qtpy.QtGui import QDrag, QKeyEvent
 from qtpy.QtCore import (
@@ -91,7 +91,7 @@ class ArchiveResultsTableModel(QAbstractTableModel):
         self.endInsertRows()
         self.layoutChanged.emit()
 
-    def replace_rows(self, pvs: List[str]) -> None:
+    def replace_rows(self, pvs: list[str]) -> None:
         """Overwrites any existing rows in the table with the input list of PV names"""
         self.beginInsertRows(QModelIndex(), 0, len(pvs) - 1)
         self.results_list = pvs

--- a/trace/widgets/color_button.py
+++ b/trace/widgets/color_button.py
@@ -1,5 +1,5 @@
 from random import random
-from typing import Any, Union
+from typing import Any
 
 from qtpy.QtGui import QColor, QMouseEvent
 from qtpy.QtCore import Qt, Signal
@@ -25,7 +25,7 @@ class ColorButton(QPushButton):
 
     color_changed = Signal(QColor)
 
-    def __init__(self, *args: Any, color: Union[QColor, str] = None, index: int = -1, **kwargs) -> None:
+    def __init__(self, *args: Any, color: QColor | str = None, index: int = -1, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if not color:
             if index >= 0:

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from qtpy.QtGui import QColor
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QWidget, QCheckBox, QLineEdit, QVBoxLayout
@@ -126,7 +124,7 @@ class CurveSettingsModal(QWidget):
         self.curve.color = color
 
     @Slot(object)
-    def set_curve_type(self, curve_type: Optional[str]) -> None:
+    def set_curve_type(self, curve_type: str | None = None) -> None:
         self.curve.stepMode = curve_type
 
     @Slot(object)

--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -2,7 +2,6 @@ import os
 import re
 import json
 import logging
-from typing import Iterable
 from pathlib import Path
 from datetime import datetime, timezone
 
@@ -136,7 +135,7 @@ class DataVisualizationModel(QAbstractTableModel):
         self.description = description
         self.description_changed.emit()
 
-    def set_all_data(self, curve_item: TimePlotCurveItem, x_range: Iterable[int]) -> None:
+    def set_all_data(self, curve_item: TimePlotCurveItem, x_range: list[int] | tuple[int, int]) -> None:
         """Set the model's data for the given curve and the given time range.
         This function determines what kind of data should be saved and prompts
         the methods for setting live or archived data as necessary. This also
@@ -146,7 +145,7 @@ class DataVisualizationModel(QAbstractTableModel):
         ----------
         curve_item : TimePlotCurveItem
             The curve for the model to collect and store data on
-        x_range : Iterable[int]
+        x_range : list[int] | tuple[int, int]
             The time range to collect and store data between
         """
         self.address = curve_item.address if curve_item.address else ""
@@ -177,7 +176,7 @@ class DataVisualizationModel(QAbstractTableModel):
             # Emulate network reply being recieved for parent widget
             self.reply_recieved.emit()
 
-    def set_live_data(self, curve_item: TimePlotCurveItem, x_range: Iterable[int]) -> None:
+    def set_live_data(self, curve_item: TimePlotCurveItem, x_range: list[int] | tuple[int, int]) -> None:
         """Set the live data for the given curve in the given time range. Appends
         rows within the time range to the end of the model's dataframe.
 
@@ -185,7 +184,7 @@ class DataVisualizationModel(QAbstractTableModel):
         ----------
         curve_item : TimePlotCurveItem
             The curve for the model to collect and store data on
-        x_range : Iterable[int]
+        x_range : list[int] | tuple[int, int]
             The time range to collect and store data between
         """
         data_n = curve_item.points_accumulated
@@ -208,7 +207,7 @@ class DataVisualizationModel(QAbstractTableModel):
         self.df = live_df
         self.endResetModel()
 
-    def request_archive_data(self, pv_name: str, x_range: Iterable[int]) -> None:
+    def request_archive_data(self, pv_name: str, x_range: list[int] | tuple[int, int]) -> None:
         """Request data from the Archiver Appliance for the given PV and time range.
         Only gets raw data, never optimized. Ends early if there is no environment
         variable PYDM_ARCHIVER_URL, which would contain the url for the Archiver
@@ -218,7 +217,7 @@ class DataVisualizationModel(QAbstractTableModel):
         ----------
         pv_name : str
             The PV address to request data for
-        x_range : Iterable[int]
+        x_range : list[int] | tuple[int, int]
             The time range to collect and store data between
         """
         # Check the $PYDM_ARCHIVER_URL is populated

--- a/trace/widgets/elog_post_modal.py
+++ b/trace/widgets/elog_post_modal.py
@@ -105,7 +105,7 @@ class ElogPostModal(QDialog):
         return title, body, logbooks, attach_config
 
     @classmethod
-    def maybe_create(cls, parent: QWidget = None, image_bytes: bytes | None = None) -> "ElogPostModal" | None:
+    def maybe_create(cls, parent: QWidget = None, image_bytes: bytes | None = None) -> "ElogPostModal | None":
         """
         Creates and shows the ElogPostModal dialog if the logbook list can be populated.
         """

--- a/trace/widgets/elog_post_modal.py
+++ b/trace/widgets/elog_post_modal.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple, Optional
-
 from qtpy.QtGui import QPixmap
 from qtpy.QtWidgets import (
     QLabel,
@@ -23,7 +21,7 @@ class ElogPostModal(QDialog):
     def __init__(
         self,
         parent: QWidget = None,
-        image_bytes: Optional[bytes] = None,
+        image_bytes: bytes | None = None,
     ):
         super().__init__(parent)
 
@@ -96,7 +94,7 @@ class ElogPostModal(QDialog):
 
         self.accept()
 
-    def get_inputs(self) -> Tuple[str, str, List[str], bool]:
+    def get_inputs(self) -> tuple[str, str, list[str], bool]:
         """
         Returns the inputs from the dialog as a tuple of (title, body, logbooks, attach_config).
         """
@@ -107,7 +105,7 @@ class ElogPostModal(QDialog):
         return title, body, logbooks, attach_config
 
     @classmethod
-    def maybe_create(cls, parent: QWidget = None, image_bytes: Optional[bytes] = None) -> Optional["ElogPostModal"]:
+    def maybe_create(cls, parent: QWidget = None, image_bytes: bytes | None = None) -> "ElogPostModal" | None:
         """
         Creates and shows the ElogPostModal dialog if the logbook list can be populated.
         """

--- a/trace/widgets/settings_components.py
+++ b/trace/widgets/settings_components.py
@@ -1,5 +1,3 @@
-from typing import Dict, List, Tuple, Union, Optional
-
 from qtpy.QtGui import QFont
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
@@ -37,9 +35,7 @@ class SettingsRowItem(QHBoxLayout):
 class ComboBoxWrapper(QComboBox):
     text_changed = Signal(object)
 
-    def __init__(
-        self, parent: QWidget, data_source: Union[List, Tuple, Dict], init_value: Optional[Union[int, str]] = None
-    ):
+    def __init__(self, parent: QWidget, data_source: list | tuple | dict, init_value: int | str | None = None):
         super().__init__(parent)
         if isinstance(data_source, (list, tuple)):
             data_source = {v: v for v in data_source}


### PR DESCRIPTION
## Description
Upgrading the version of Python used to 3.12. This is because SLAC & PyDM are now on 3.12, and it'd be good to keep up with them. These changes were done in the GH workflows and the environment file.

Also translated all previous type hints from the `typing` library to the built-in Python type hints.