### PR TITLE
Live + archive data moved to curve settings

### DIFF
--- a/trace/widgets/control_panel.py
+++ b/trace/widgets/control_panel.py
@@ -494,31 +494,24 @@ class CurveItem(QtWidgets.QWidget):
         self.pv_settings_modal = None
         self.pv_settings_button.clicked.connect(self.show_settings_modal)
         pv_settings_layout.addWidget(self.pv_settings_button)
+
+        self.live_connection_status = QtWidgets.QLabel()
+        self.live_connection_status.setPixmap(self.icon_disconnected.pixmap(16, 16))
+        self.live_connection_status.setToolTip("Not connected to live data")
+        self.source.live_channel_connection.connect(self.update_live_icon)
+        pv_settings_layout.addWidget(self.live_connection_status)
+
+        self.archive_connection_status = QtWidgets.QLabel()
+        self.archive_connection_status.setPixmap(self.icon_disconnected.pixmap(16, 16))
+        self.archive_connection_status.setToolTip("Not connected to archive data")
+        self.source.archive_channel_connection.connect(self.update_archive_icon)
+        pv_settings_layout.addWidget(self.archive_connection_status)
+
         self.delete_button = QtWidgets.QPushButton()
         self.delete_button.setIcon(qta.icon("msc.trash"))
         self.delete_button.setFlat(True)
         self.delete_button.clicked.connect(self.close)
         pv_settings_layout.addWidget(self.delete_button)
-
-        self.live_toggle = QtWidgets.QCheckBox("Live")
-        self.live_toggle.setCheckState(QtCore.Qt.Checked if self.source.liveData else QtCore.Qt.Unchecked)
-        self.live_toggle.stateChanged.connect(self.set_live_data_connection)
-        data_type_layout.addWidget(self.live_toggle)
-        self.live_connection_status = QtWidgets.QLabel()
-        self.live_connection_status.setPixmap(self.icon_disconnected.pixmap(16, 16))
-        self.live_connection_status.setToolTip("Not connected to live data")
-        self.source.live_channel_connection.connect(self.update_live_icon)
-        data_type_layout.addWidget(self.live_connection_status)
-
-        self.archive_toggle = QtWidgets.QCheckBox("Archive")
-        self.archive_toggle.setCheckState(QtCore.Qt.Checked if self.source.use_archive_data else QtCore.Qt.Unchecked)
-        self.archive_toggle.stateChanged.connect(self.set_archive_data_connection)
-        data_type_layout.addWidget(self.archive_toggle)
-        self.archive_connection_status = QtWidgets.QLabel()
-        self.archive_connection_status.setPixmap(self.icon_disconnected.pixmap(16, 16))
-        self.archive_connection_status.setToolTip("Not connected to archive data")
-        self.source.archive_channel_connection.connect(self.update_archive_icon)
-        data_type_layout.addWidget(self.archive_connection_status)
 
         data_type_layout.addStretch()
 
@@ -539,12 +532,6 @@ class CurveItem(QtWidgets.QWidget):
             self.source.hide()
         else:
             self.source.show()
-
-    def set_live_data_connection(self, state: QtCore.Qt.CheckState) -> None:
-        self.source.liveData = state == QtCore.Qt.Checked
-
-    def set_archive_data_connection(self, state: QtCore.Qt.CheckState) -> None:
-        self.source.use_archive_data = state == QtCore.Qt.Checked
 
     def update_live_icon(self, connected: bool) -> None:
         self.live_connection_status.setVisible(not connected)

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -1,6 +1,7 @@
 from qtpy.QtGui import QColor
 from qtpy.QtCore import Qt, Slot
-from qtpy.QtWidgets import QWidget, QCheckBox, QLineEdit, QVBoxLayout
+from qtpy.QtWidgets import QWidget, QCheckBox, QLineEdit, QVBoxLayout, QLabel
+from qtawesome import icon
 
 from pydm.widgets.archiver_time_plot import TimePlotCurveItem, PyDMArchiverTimePlot
 
@@ -40,6 +41,18 @@ class CurveSettingsModal(QWidget):
             bin_count = plot.optimized_data_bins
         bin_count_line_edit.setPlaceholderText(str(bin_count))
         main_layout.addLayout(optimized_bin_count)
+
+        self.live_toggle = QCheckBox("")
+        self.live_toggle.setCheckState(Qt.Checked if self.curve.liveData else Qt.Unchecked)
+        self.live_toggle.stateChanged.connect(self.set_live_data_connection)
+        live_toggle_row = SettingsRowItem(self, "Connect to Live", self.live_toggle)
+        main_layout.addLayout(live_toggle_row)
+
+        self.archive_toggle = QCheckBox("")
+        self.archive_toggle.setCheckState(Qt.Checked if self.curve.use_archive_data else Qt.Unchecked)
+        self.archive_toggle.stateChanged.connect(self.set_archive_data_connection)
+        archive_toggle_row = SettingsRowItem(self, "Connect to Archive", self.archive_toggle)
+        main_layout.addLayout(archive_toggle_row)
 
         line_title_label = SettingsTitle(self, "Line")
         main_layout.addWidget(line_title_label)
@@ -94,6 +107,12 @@ class CurveSettingsModal(QWidget):
             self.bin_count_line_edit.setPlaceholderText(str(n_bins))
         except (AttributeError, ValueError) as e:
             logger.warning(f"Unable to set data bins: {e}")
+    
+    def set_live_data_connection(self, state: Qt.CheckState) -> None:
+        self.curve.liveData = state == Qt.Checked
+
+    def set_archive_data_connection(self, state: Qt.CheckState) -> None:
+        self.curve.use_archive_data = state == Qt.Checked
 
     def show(self):
         parent_pos = self.parent().rect().bottomRight()

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -1,7 +1,6 @@
 from qtpy.QtGui import QColor
 from qtpy.QtCore import Qt, Slot
-from qtpy.QtWidgets import QWidget, QCheckBox, QLineEdit, QVBoxLayout, QLabel
-from qtawesome import icon
+from qtpy.QtWidgets import QWidget, QCheckBox, QLineEdit, QVBoxLayout
 
 from pydm.widgets.archiver_time_plot import TimePlotCurveItem, PyDMArchiverTimePlot
 

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -107,7 +107,7 @@ class CurveSettingsModal(QWidget):
             self.bin_count_line_edit.setPlaceholderText(str(n_bins))
         except (AttributeError, ValueError) as e:
             logger.warning(f"Unable to set data bins: {e}")
-    
+
     def set_live_data_connection(self, state: Qt.CheckState) -> None:
         self.curve.liveData = state == Qt.Checked
 

--- a/trace/widgets/plot_settings.py
+++ b/trace/widgets/plot_settings.py
@@ -47,6 +47,7 @@ class PlotSettingsModal(QWidget):
 
         self.legend_checkbox = QCheckBox(self)
         self.legend_checkbox.stateChanged.connect(lambda check: self.plot.setShowLegend(bool(check)))
+        self.legend_checkbox.setChecked(True)  # legend on by default
         legend_row = SettingsRowItem(self, "Show Legend", self.legend_checkbox)
         main_layout.addLayout(legend_row)
 


### PR DESCRIPTION
* Moved live and archive data option check boxes from control panel to curve settings modal
  * Live and archive connection status indicators are still on the control panel, moved them to be inline with label, settings and delete buttons
* Also added legend on by default to this PR
<img width="537" height="237" alt="Screenshot 2025-08-22 at 15 36 59" src="https://github.com/user-attachments/assets/8b40f8b4-d7bb-4b46-9c5e-48bef60c2093" />
<img width="280" height="467" alt="Screenshot 2025-08-22 at 15 37 10" src="https://github.com/user-attachments/assets/7d5585a4-210d-4ae1-9f37-4759c1fd7297" />


