### PR TITLE
ENH: New Curves Are Added to Axes Based on Units

### DIFF
--- a/trace/stylesheets/dark_mode.qss
+++ b/trace/stylesheets/dark_mode.qss
@@ -83,7 +83,6 @@ QPushButton:disabled, PyDMPushButton:disabled {
     background-color: #2F2F2F;
     color: #7A7A7A;
     border: 1px solid #444444;
-    cursor: not-allowed;
 }
 
 /* Flat Icon Buttons */

--- a/trace/stylesheets/light_mode.qss
+++ b/trace/stylesheets/light_mode.qss
@@ -83,7 +83,6 @@ QPushButton:disabled, PyDMPushButton:disabled {
     background-color: #F0F0F0;
     color: #AAAAAA;
     border: 1px solid #DDDDDD;
-    cursor: not-allowed;
 }
 
 /* Flat Icon Buttons */

--- a/trace/widgets/control_panel.py
+++ b/trace/widgets/control_panel.py
@@ -191,7 +191,7 @@ class ControlPanel(QtWidgets.QWidget):
 
         self.plot.addAxis(plot_data_item=None, name=name, orientation="left", label=name)
         new_axis = self.plot._axes[-1]
-        new_axis.setLabel(name, color="black")
+        new_axis.setLabel(name, color=self.theme_manager.get_icon_color())
 
         return self.add_axis_item(new_axis)
 
@@ -430,6 +430,10 @@ class AxisItem(QtWidgets.QWidget):
         """Handle theme changes by updating icons"""
         self.update_icons()
 
+        # Change axis label color to match theme
+        label_text = self.source.labelText
+        self.source.setLabel(label_text, color=self.theme_manager.get_icon_color())
+
     @property
     def plot(self):
         return self.parent().parent().parent().parent().plot
@@ -441,7 +445,6 @@ class AxisItem(QtWidgets.QWidget):
 
     def make_curve_widget(self, plot_curve_item: ArchivePlotCurveItem | FormulaCurveItem) -> "CurveItem":
         curve_item = CurveItem(self, plot_curve_item)
-        curve_item.curve_deleted.connect(self.curves_list_changed.emit)
         curve_item.curve_deleted.connect(lambda curve: self.handle_curve_deleted(curve))
         curve_item.active_toggle.setCheckState(self.active_toggle.checkState())
 

--- a/trace/widgets/control_panel.py
+++ b/trace/widgets/control_panel.py
@@ -922,7 +922,7 @@ class CurveItem(QtWidgets.QWidget):
 
     def show_invalid_icon(self, show=True):
         """Show or hide the invalid formula icon overlaid on the line edit"""
-        if not self.is_formula_curve:
+        if not self.is_formula_curve():
             return
 
         if show:
@@ -1113,7 +1113,7 @@ class CurveItem(QtWidgets.QWidget):
         if pv is None and self.sender():
             pv = self.sender().text()
 
-        if self.is_formula_curve:
+        if self.is_formula_curve():
             self.update_formula()
             return
 

--- a/trace/widgets/control_panel.py
+++ b/trace/widgets/control_panel.py
@@ -163,7 +163,13 @@ class ControlPanel(QtWidgets.QWidget):
         return self._curve_dict
 
     def _generate_curve_key(self):
-        """Generate a unique variable name for a curve, either pv or formula."""
+        """Generate a unique variable name for a curve, either pv or formula.
+
+        Yields
+        ------
+        key : str
+            The next unique key for the curve. Yielded when a curve is sent.
+        """
         key = None
         next_pv_num = 1
         next_formula_num = 1
@@ -318,6 +324,18 @@ class ControlPanel(QtWidgets.QWidget):
         self.axis_list.itemAt(self.axis_list.count() - 2).widget()
 
     def move_curve_to_axis(self, curve_item: "CurveItem", target_axis_name: str) -> None:
+        """Remove a given CurveItem from its current AxisItem and add it to
+        the AxisItem with the given target axis name. If no such AxisItem
+        exists, a new one will be created. Intended to be used for Axes
+        named after a curve's unit.
+
+        Parameters
+        ----------
+        curve_item : CurveItem
+            CurveItem to be moved to a new axis.
+        target_axis_name : str
+            Name of the target axis to move the CurveItem to.
+        """
         axis_item = self.get_axis_item(target_axis_name)
         if axis_item is None:
             axis_item = self.add_empty_axis(target_axis_name)
@@ -444,6 +462,19 @@ class AxisItem(QtWidgets.QWidget):
         return self.source.name
 
     def make_curve_widget(self, plot_curve_item: ArchivePlotCurveItem | FormulaCurveItem) -> "CurveItem":
+        """Create a CurveItem widget for the given plot curve item and add
+        it to this AxisItem.
+
+        Parameters
+        ----------
+        plot_curve_item : ArchivePlotCurveItem | FormulaCurveItem
+            The plot curve item to create a CurveItem for.
+
+        Returns
+        -------
+        CurveItem
+            The created CurveItem widget.
+        """
         curve_item = CurveItem(self, plot_curve_item)
         curve_item.curve_deleted.connect(lambda curve: self.handle_curve_deleted(curve))
         curve_item.active_toggle.setCheckState(self.active_toggle.checkState())
@@ -457,6 +488,22 @@ class AxisItem(QtWidgets.QWidget):
         return curve_item
 
     def add_curve(self, pv: str, channel_args: dict = None) -> "CurveItem":
+        """Create a new ArchivePlotCurveItem for the given PV and add it
+        to this AxisItem. Also creates a CurveItem widget for it.
+
+        Parameters
+        ----------
+        pv : str
+            The process variable name to create the curve for.
+        channel_args : dict, optional
+            The arguments to pass to the ArchivePlotCurveItem constructor,
+            by default None
+
+        Returns
+        -------
+        CurveItem
+            The created CurveItem widget.
+        """
         color = ColorButton.index_color(len(self.plot._curves))
         args = {
             "y_channel": pv,
@@ -473,6 +520,19 @@ class AxisItem(QtWidgets.QWidget):
         return self.make_curve_widget(plot_curve_item)
 
     def add_formula_curve(self, formula: str) -> "CurveItem":
+        """Create a new FormulaCurveItem for the given formula and add it
+        to this AxisItem. Also creates a CurveItem widget for it.
+
+        Parameters
+        ----------
+        formula : str
+            The formula to create the curve for. Must start with "f://".
+
+        Returns
+        -------
+        CurveItem
+            The created CurveItem widget.
+        """
         var_names = re.findall(r"{(.+?)}", formula)
         var_dict = {}
 
@@ -761,6 +821,7 @@ class CurveItem(QtWidgets.QWidget):
 
     @property
     def plot(self):
+        """Get the PlotWidget that this CurveItem belongs to."""
         return self.control_panel.plot
 
     @property


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
When a user creates a new curve, it is added to an axis based on the channels units (if the `.EGU` field is populated). If an axis for that unit does not exist, a new one will be created. The axes will have the unit as the name (e.g. '%', 'bara', 'deg_F').

If a new curve does not have units (formula, no `.EGU` field, no live data) it will be added to a unitless axis named 'Axis 1' or something similar.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This groups like curves onto the same axes, giving the data context. This feature also existed before the UI was redesigned and it'd be nice to bring it back.
Closes SWAPPS-248

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
<img width="2056" height="1300" alt="Screenshot 2025-09-10 at 10 37 15" src="https://github.com/user-attachments/assets/4dd218fa-2edd-4322-ab69-c5202f6e65b5" />

## Pre-merge checklist

- [x] Code works interactively
- [x] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
