### PR TITLE
FIX: Hide Bin Count Setting for FormulaCurves

### DIFF
--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -33,15 +33,17 @@ class CurveSettingsModal(QWidget):
         color_row = SettingsRowItem(self, "Color", color_button)
         main_layout.addLayout(color_row)
 
-        self.bin_count_line_edit = bin_count_line_edit = QLineEdit()
-        bin_count_line_edit.setMaximumWidth(65)
-        bin_count_line_edit.returnPressed.connect(self.set_curve_data_bins)
-        optimized_bin_count = SettingsRowItem(self, "Optimized bin count", bin_count_line_edit)
-        bin_count = curve.optimized_data_bins
-        if not bin_count:
-            bin_count = plot.optimized_data_bins
-        bin_count_line_edit.setPlaceholderText(str(bin_count))
-        main_layout.addLayout(optimized_bin_count)
+        self.bin_count_line_edit = None
+        if hasattr(curve, "setOptimizedDataBins"):
+            self.bin_count_line_edit = bin_count_line_edit = QLineEdit()
+            bin_count_line_edit.setMaximumWidth(65)
+            bin_count_line_edit.returnPressed.connect(self.set_curve_data_bins)
+            optimized_bin_count = SettingsRowItem(self, "Optimized bin count", bin_count_line_edit)
+            bin_count = curve.optimized_data_bins
+            if not bin_count:
+                bin_count = plot.optimized_data_bins
+            bin_count_line_edit.setPlaceholderText(str(bin_count))
+            main_layout.addLayout(optimized_bin_count)
 
         self.live_toggle = QCheckBox("")
         self.live_toggle.setCheckState(Qt.Checked if self.curve.liveData else Qt.Unchecked)
@@ -116,11 +118,14 @@ class CurveSettingsModal(QWidget):
         self.curve.use_archive_data = state == Qt.Checked
 
     def show(self):
+        # Reset Bin Count LineEdit if it exists
+        if self.bin_count_line_edit:
+            self.bin_count_line_edit.setStyleSheet("")
+            self.bin_count_line_edit.setText("")
+
         parent_pos = self.parent().rect().bottomRight()
         global_pos = self.parent().mapToGlobal(parent_pos)
         self.move(global_pos)
-        self.bin_count_line_edit.setStyleSheet("")
-        self.bin_count_line_edit.setText("")
         super().show()
 
     @Slot()


### PR DESCRIPTION
## Description
Fixes error with `CurveSettingsModal`. The widget would try to reference a non existent property for `FormulaCurveItem`s. This PR adds a check to prevent referencing the property if it doesn't exist.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The error below would come up when opening the settings for a Formula curve:
```
Traceback (most recent call last):
  File "/sdf/home/z/zdomke/workspace/trace/trace/trace/widgets/control_panel.py", line 968, in show_settings_modal
    self.pv_settings_modal = CurveSettingsModal(self.pv_settings_button, self.plot, self.source)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sdf/home/z/zdomke/workspace/trace/trace/trace/widgets/curve_settings.py", line 40, in __init__
    bin_count = curve.optimized_data_bins
                ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'FormulaCurveItem' object has no attribute 'optimized_data_bins'
```

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
Curve Settings, includes line labeled "Optimized bin count":
<img width="251" height="401" alt="Screenshot 2025-09-17 at 12 00 01" src="https://github.com/user-attachments/assets/aa43398e-4161-411e-89dd-83329136637c" />

Formula Curve Settings, does not include line labeled "Optimized bin count":
<img width="251" height="369" alt="Screenshot 2025-09-17 at 12 00 04" src="https://github.com/user-attachments/assets/f18c29ba-47db-41f3-a82c-d7dfb315d1f2" />


## Pre-merge checklist

- [x] Code works interactively
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
