### PR TITLE
FIX: Catch Interruption Exception in CAGetThread

### DIFF
--- a/trace/widgets/data_insight_tool.py
+++ b/trace/widgets/data_insight_tool.py
@@ -65,11 +65,18 @@ class CAGetThread(QThread):
         self.stop_flag = False
 
     def run(self) -> None:
-        value = epics.caget(self.address)
+        """Get the value for the given address. Interruptable via the
+        stop_flag. Does not attempt to emit the PV Value if interrupted.
+        """
+        pv = epics.PV(self.address)
 
         if self.stop_flag:
             return
-        self.result_ready.emit(value)
+
+        try:
+            self.result_ready.emit(pv.value)
+        except epics.ca.ChannelAccessException as e:
+            logger.warning(f"Channel Access error: {e}")
 
     def stop(self) -> None:
         """Set the stop flag"""


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
This PV catches an exception in `CAGetThread` when users close the application soon after the thread is started. This prevents the thread from delaying the app closing as well as the thread throwing an error if the connection is not made.

This PR also moves away from `epics.caget()` in `CAGetThread` and instead uses `epics.PV` objects. This was done because the PV objects handled interruption better and did not print an error message if they timed out.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A nasty error was displayed if users closed the application while the `CAGetThread` was still running. The error was
`epics.ca.ChannelAccessException: Unexpected channel ID`.

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
