### PR TITLE
FIX: Fix File Indicator Slot

### DIFF
--- a/trace/main.py
+++ b/trace/main.py
@@ -3,6 +3,7 @@ import argparse
 import subprocess
 from socket import gethostname
 from getpass import getuser
+from pathlib import Path
 from datetime import datetime
 
 from qtpy.QtGui import QFont, QColor, QImage, QKeySequence
@@ -331,13 +332,13 @@ class TraceDisplay(Display):
 
         return footer_widget
 
-    @Slot(str)
-    def set_file_indicator(self, file_path: str) -> None:
+    @Slot(Path)
+    def set_file_indicator(self, file_path: Path) -> None:
         """Set the file indicator label to the given file path.
 
         Parameters
         ----------
-        file_path : str
+        file_path : Path
             The file path to set the label to.
 
         Returns
@@ -347,7 +348,7 @@ class TraceDisplay(Display):
         """
         if not file_path:
             return
-        filename = os.path.basename(file_path)
+        filename = file_path.name
         if hasattr(self, "file_label") and self.file_label is not None:
             self.file_label.setText(filename)
         else:


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Fixes a bug with the slot for displaying the current imported file name on the footer.

I incorrectly defined `set_file_indicator()`'s argument as being a `str` when it should be a `pathlib.Path` object. This caused PyQT to believe that the slot was incorrect and it threw an error.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing a small bug.

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
<img width="2056" height="1300" alt="Screenshot 2025-10-06 at 11 03 00" src="https://github.com/user-attachments/assets/3df657b5-df2b-4f34-a889-acdc04e096b5" />

## Pre-merge checklist

- [x] Code works interactively
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
